### PR TITLE
feat(thinking): tighten prompt, enforce length caps, trim response echo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ This is the Go successor to `jacaudi/http-sequential-thinking`. Breaking changes
 - **Server name renamed:** `sequential-thinking-server` → `rubber-ducky-thinking`.
 - **Web UI removed.** Use MCP Inspector or `curl` for manual testing.
 - **CORS default tightened.** Set `ALLOWED_ORIGINS` explicitly to allow browser clients.
+- **Length caps on critical fields (server-side).** `critique` ≤ 280 chars, `counterArgument` ≤ 280, each `assumptions[i]` ≤ 200, `nextStepRationale` ≤ 200 (only enforced when `nextThoughtNeeded=true`). Caps are rune-counted and force one-sentence-per-field discipline; padded prose returns `IsError: true`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ This is the Go successor to `jacaudi/http-sequential-thinking`. Breaking changes
 - **Web UI removed.** Use MCP Inspector or `curl` for manual testing.
 - **CORS default tightened.** Set `ALLOWED_ORIGINS` explicitly to allow browser clients.
 - **Length caps on critical fields (server-side).** `critique` ≤ 280 chars, `counterArgument` ≤ 280, each `assumptions[i]` ≤ 200, `nextStepRationale` ≤ 200 (only enforced when `nextThoughtNeeded=true`). Caps are rune-counted and force one-sentence-per-field discipline; padded prose returns `IsError: true`.
+- **`thoughtNumber` and `totalThoughts` are now optional after the first thought.** Omit `thoughtNumber` to let the server auto-assign the next sequential position (trunk: history+1; branch: branch-depth, i.e. position within the branch — *not* a global ordinal). Omit `totalThoughts` to inherit the most recent *trunk* thought's value (branch thoughts don't contaminate the inheritance). The first trunk thought of a session must still include `totalThoughts`. Sending them explicitly is still accepted and overrides. If your client treats stored `thoughtNumber` on branch thoughts as a global ordinal, keep sending it explicitly.
+- **Response no longer echoes `thoughtNumber`, `totalThoughts`, or `nextThoughtNeeded`.** Callers already have these — the response now contains only `branches`, `thoughtHistoryLength`, `sessionConfidence`, and `branchConfidences` (when present). Read the full per-thought state from the `thinking://current` resource if you need it.
 
 ## Development
 

--- a/internal/thinking/description.go
+++ b/internal/thinking/description.go
@@ -28,6 +28,11 @@ How a session unfolds:
   - You start at thoughtNumber=1 with an estimated totalThoughts. Each call
     produces one thought + its critique. The next call builds on what came
     before — including, importantly, on what your own critique surfaced.
+  - thoughtNumber and totalThoughts are OPTIONAL after the first call: omit
+    thoughtNumber to let the server auto-assign the next sequential position;
+    omit totalThoughts to inherit the value from the prior thought. Send them
+    only when you need to override (revisions, branches, or a changed
+    estimate). The first thought of a session must include totalThoughts.
   - When a critique reveals that an earlier thought was wrong, use isRevision
     + revisesThought to revisit it. The new critique should explain *why*
     the old one was wrong.
@@ -35,8 +40,8 @@ How a session unfolds:
     branchFromThought + branchId together. Branches accumulate their own
     running confidence average — if a branch is averaging 0.4, that's a
     signal the path is shaky.
-  - Adjust totalThoughts as understanding evolves. Set nextThoughtNeeded=false
-    only when the work is genuinely done.
+  - Adjust totalThoughts as understanding evolves (resend it when changed).
+    Set nextThoughtNeeded=false only when the work is genuinely done.
 
 For each call, you write ONE thought as if explaining it to a patient listener.
 Then, in the same call, you provide:
@@ -88,7 +93,12 @@ What you get back:
   - A narrated transcript of this thought (rendered in rubber-duck voice).
   - Running session confidence (mean of trunk thoughts).
   - Per-branch confidence (if any branches exist).
-  - The full state needed to plan the next call.
+  - thoughtHistoryLength and the list of branch ids.
+
+The response deliberately does NOT echo thoughtNumber, totalThoughts, or
+nextThoughtNeeded — you sent those, you already have them. Track session
+position locally; the server is the source of truth via the
+thinking://current resource.
 
 Use this when the problem deserves slow, examined, multi-step thinking. Don't
 use it for trivia or one-step lookups — the ceremony will get in the way. Use

--- a/internal/thinking/description.go
+++ b/internal/thinking/description.go
@@ -43,19 +43,27 @@ Then, in the same call, you provide:
 
   - confidence (0.0–1.0): How sure are you, *honestly*? 0.5 means a coin flip.
                           High confidence (>0.8) requires evidence, not enthusiasm.
-  - assumptions (string[]): What are you taking for granted? List them. If you
-                            genuinely believe there are none, send [] and own that
-                            claim.
-  - critique (string, required, non-empty): What is weak, suspect, or
-                            under-examined about the thought you just produced?
-                            "Looks good" is not a critique. Be your own toughest
-                            reviewer.
-  - counterArgument (string, required, non-empty): The strongest case AGAINST
-                            this thought. Steelman the opposition. If you can't
+  - assumptions (string[]): What are you taking for granted? List them as
+                            bullets — each one ≤ 200 chars, one fact per entry.
+                            Send [] only if you've genuinely accounted for none.
+  - critique (string, required, non-empty, ≤ 280 chars):
+                            What is weak, suspect, or under-examined about the
+                            thought you just produced? One tight sentence naming
+                            a SPECIFIC weakness. "Looks good" is not a critique;
+                            neither is a paragraph of generic self-doubt.
+  - counterArgument (string, required, non-empty, ≤ 280 chars):
+                            The strongest case AGAINST this thought, in one
+                            sentence. Steelman the opposition. If you can't
                             think of one, your confidence is wrong.
-  - nextStepRationale (string, required when nextThoughtNeeded=true):
+  - nextStepRationale (string, ≤ 200 chars, REQUIRED when nextThoughtNeeded=true,
+                            OMIT when nextThoughtNeeded=false):
                             Why is *this* the next thought, not some other one?
-                            What did this one rule out, open up, or expose?
+                            One sentence: what this thought ruled out, opened up,
+                            or exposed.
+
+Brevity discipline: 'thought' is your narration; the critical fields are
+bullets, not paragraphs. One tight sentence each, enforced server-side. A
+specific weakness in 20 words beats vague self-doubt in 200.
 
 Voice and register for the thought field:
   - First-person, narrative, exploratory. "I think... but wait... actually..."

--- a/internal/thinking/description.go
+++ b/internal/thinking/description.go
@@ -23,25 +23,11 @@ you talk to while you think one step at a time. This tool fuses three discipline
 Sequential thinking is the *spine*. Rubber-ducking is the *voice*. Critical
 self-examination is the *check*. Skipping any one of them is a misuse.
 
-How a session unfolds:
-
-  - You start at thoughtNumber=1 with an estimated totalThoughts. Each call
-    produces one thought + its critique. The next call builds on what came
-    before — including, importantly, on what your own critique surfaced.
-  - thoughtNumber and totalThoughts are OPTIONAL after the first call: omit
-    thoughtNumber to let the server auto-assign the next sequential position;
-    omit totalThoughts to inherit the value from the prior thought. Send them
-    only when you need to override (revisions, branches, or a changed
-    estimate). The first thought of a session must include totalThoughts.
-  - When a critique reveals that an earlier thought was wrong, use isRevision
-    + revisesThought to revisit it. The new critique should explain *why*
-    the old one was wrong.
-  - When the path forks and you want to explore an alternative, use
-    branchFromThought + branchId together. Branches accumulate their own
-    running confidence average — if a branch is averaging 0.4, that's a
-    signal the path is shaky.
-  - Adjust totalThoughts as understanding evolves (resend it when changed).
-    Set nextThoughtNeeded=false only when the work is genuinely done.
+How a session unfolds: each call produces one thought + its critique. The
+next call builds on everything that came before — including, importantly, on
+what your own prior critique surfaced. Sequential is not just numbering; it
+means each thought *uses* what came before. See "Structural fields" below
+for the mechanics (revisions, branches, position, totals).
 
 For each call, you write ONE thought as if explaining it to a patient listener.
 Then, in the same call, you provide:
@@ -69,6 +55,57 @@ Then, in the same call, you provide:
 Brevity discipline: 'thought' is your narration; the critical fields are
 bullets, not paragraphs. One tight sentence each, enforced server-side. A
 specific weakness in 20 words beats vague self-doubt in 200.
+
+Structural fields (control how this call relates to prior thoughts):
+
+  - thoughtNumber (int, optional): Current position. Omit to let the server
+                            auto-assign (trunk: history+1; branch: depth within
+                            the branch). Send explicitly when you want to be
+                            unambiguous, e.g. on revisions.
+  - totalThoughts (int, required on the first trunk thought, optional after):
+                            Your current estimate of how many thoughts you'll
+                            need. Resend when revised; omit to inherit the prior
+                            trunk thought's value. Adjust up if you realize more
+                            is needed — the server auto-bumps if your
+                            thoughtNumber exceeds totalThoughts.
+  - nextThoughtNeeded (bool, required): true if you need another thought, even
+                            when you thought you were done. Set false only when
+                            you have a satisfactory answer.
+  - isRevision (bool) + revisesThought (int): Use together when this thought
+                            revises an earlier one. The critique on the revising
+                            thought should explain *why* the previous thinking
+                            was wrong — not just restate the new view.
+  - branchFromThought (int) + branchId (string): Use together to fork into an
+                            alternative path from a specific prior thought.
+                            Branches accumulate their own running confidence
+                            average; a branch averaging low confidence is a
+                            signal the path is shaky.
+  - needsMoreThoughts (bool, optional): Set true when you reach the end of your
+                            estimate but realize more thinking is needed. This
+                            is a self-signal — it doesn't itself extend the
+                            session; raise totalThoughts to do that.
+
+When to use this tool:
+  - Breaking complex problems into ordered, examined steps
+  - Multi-step solutions that need to maintain context across calls
+  - Analysis that may need course correction as understanding deepens
+  - Problems where the full scope isn't clear at the start
+  - Decisions where being wrong is expensive
+  - Situations where filtering irrelevant context matters
+
+Process guidance:
+  1. Start with an initial totalThoughts estimate; be ready to adjust.
+  2. Question and revise previous thoughts when your critique surfaces a flaw
+     (isRevision + revisesThought).
+  3. Add more thoughts past the estimate when needed (set needsMoreThoughts and
+     raise totalThoughts).
+  4. Express uncertainty honestly via confidence, assumptions, and critique.
+  5. Branch when paths diverge (branchFromThought + branchId); don't conflate
+     alternatives onto the trunk.
+  6. Generate a hypothesis, then verify it across subsequent thoughts.
+  7. Filter irrelevant information — not every prior detail matters at every
+     step.
+  8. Set nextThoughtNeeded=false only when you have a satisfactory answer.
 
 Voice and register for the thought field:
   - First-person, narrative, exploratory. "I think... but wait... actually..."

--- a/internal/thinking/schema.go
+++ b/internal/thinking/schema.go
@@ -6,6 +6,17 @@ package thinking
 import (
 	"errors"
 	"fmt"
+	"unicode/utf8"
+)
+
+// Length caps on the critical-thinking fields. Limits are in runes, not bytes,
+// so multi-byte text (em-dashes, accented chars) doesn't get unfairly truncated.
+// These force one-sentence-per-field discipline; padded prose returns an error.
+const (
+	maxCritiqueLen          = 280
+	maxCounterArgumentLen   = 280
+	maxNextStepRationaleLen = 200
+	maxAssumptionLen        = 200
 )
 
 // ThoughtData is the input to one criticalthinking tool call.
@@ -70,12 +81,31 @@ func (td ThoughtData) Validate() error {
 	if td.Critique == "" {
 		return errors.New("critique must be a non-empty string")
 	}
+	if n := utf8.RuneCountInString(td.Critique); n > maxCritiqueLen {
+		return fmt.Errorf("critique must be ≤ %d chars, got %d (one tight sentence; the thought field is for narration)", maxCritiqueLen, n)
+	}
 	if td.CounterArgument == "" {
 		return errors.New("counterArgument must be a non-empty string")
 	}
-	if *td.NextThoughtNeeded && td.NextStepRationale == "" {
-		return errors.New("nextStepRationale required when nextThoughtNeeded is true")
+	if n := utf8.RuneCountInString(td.CounterArgument); n > maxCounterArgumentLen {
+		return fmt.Errorf("counterArgument must be ≤ %d chars, got %d (one tight sentence; the thought field is for narration)", maxCounterArgumentLen, n)
 	}
+	for i, a := range td.Assumptions {
+		if n := utf8.RuneCountInString(a); n > maxAssumptionLen {
+			return fmt.Errorf("assumptions[%d] must be ≤ %d chars, got %d (one fact per entry)", i, maxAssumptionLen, n)
+		}
+	}
+	if *td.NextThoughtNeeded {
+		if td.NextStepRationale == "" {
+			return errors.New("nextStepRationale required when nextThoughtNeeded is true")
+		}
+		if n := utf8.RuneCountInString(td.NextStepRationale); n > maxNextStepRationaleLen {
+			return fmt.Errorf("nextStepRationale must be ≤ %d chars, got %d (one sentence)", maxNextStepRationaleLen, n)
+		}
+	}
+	// When nextThoughtNeeded=false, NextStepRationale is logically absent — we
+	// don't enforce the length cap. Clients are advised to OMIT the field; a
+	// stale value here is benign and ignored.
 
 	// Both-or-neither rule for branch fields.
 	hasFrom := td.BranchFromThought != nil

--- a/internal/thinking/schema.go
+++ b/internal/thinking/schema.go
@@ -22,12 +22,14 @@ const (
 // ThoughtData is the input to one criticalthinking tool call.
 //
 // Sent fields whose omission cannot be distinguished from their zero value
-// (NextThoughtNeeded, IsRevision, RevisesThought, BranchFromThought,
-// NeedsMoreThoughts) use pointer types so the validator can detect "not sent".
+// (ThoughtNumber, TotalThoughts, NextThoughtNeeded, IsRevision, RevisesThought,
+// BranchFromThought, NeedsMoreThoughts) use pointer types so the validator can
+// detect "not sent". For ThoughtNumber/TotalThoughts, "not sent" is a signal
+// for server-side auto-assign (next sequential / inherit prior).
 type ThoughtData struct {
 	Thought           string `json:"thought"`
-	ThoughtNumber     int    `json:"thoughtNumber"`
-	TotalThoughts     int    `json:"totalThoughts"`
+	ThoughtNumber     *int   `json:"thoughtNumber,omitempty"`
+	TotalThoughts     *int   `json:"totalThoughts,omitempty"`
 	NextThoughtNeeded *bool  `json:"nextThoughtNeeded"`
 	IsRevision        *bool  `json:"isRevision,omitempty"`
 	RevisesThought    *int   `json:"revisesThought,omitempty"`
@@ -43,10 +45,12 @@ type ThoughtData struct {
 }
 
 // ThoughtResponse is the structuredContent of a criticalthinking tool call.
+//
+// Echo fields the caller already sent (thoughtNumber, totalThoughts,
+// nextThoughtNeeded) are deliberately omitted to save tokens. The server
+// tracks them internally; callers can read them back from the
+// thinking://current resource if needed.
 type ThoughtResponse struct {
-	ThoughtNumber        int                `json:"thoughtNumber"`
-	TotalThoughts        int                `json:"totalThoughts"`
-	NextThoughtNeeded    bool               `json:"nextThoughtNeeded"`
 	Branches             []string           `json:"branches"`
 	ThoughtHistoryLength int                `json:"thoughtHistoryLength"`
 	SessionConfidence    float64            `json:"sessionConfidence"`
@@ -63,11 +67,11 @@ func (td ThoughtData) Validate() error {
 	if td.Thought == "" {
 		return errors.New("thought must be a non-empty string")
 	}
-	if td.ThoughtNumber < 1 {
-		return errors.New("thoughtNumber must be ≥ 1")
+	if td.ThoughtNumber != nil && *td.ThoughtNumber < 1 {
+		return errors.New("thoughtNumber must be ≥ 1 (omit to auto-assign)")
 	}
-	if td.TotalThoughts < 1 {
-		return errors.New("totalThoughts must be ≥ 1")
+	if td.TotalThoughts != nil && *td.TotalThoughts < 1 {
+		return errors.New("totalThoughts must be ≥ 1 (omit to inherit prior)")
 	}
 	if td.NextThoughtNeeded == nil {
 		return errors.New("nextThoughtNeeded must be present (true or false)")

--- a/internal/thinking/schema_test.go
+++ b/internal/thinking/schema_test.go
@@ -10,8 +10,8 @@ func TestThoughtDataJSONRoundTrip(t *testing.T) {
 	yes := true
 	td := ThoughtData{
 		Thought:           "I think we should normalize first",
-		ThoughtNumber:     1,
-		TotalThoughts:     3,
+		ThoughtNumber:     intPtr(1),
+		TotalThoughts:     intPtr(3),
 		NextThoughtNeeded: &yes,
 		Confidence:        0.6,
 		Assumptions:       []string{"row count is current"},
@@ -40,9 +40,6 @@ func TestThoughtDataJSONRoundTrip(t *testing.T) {
 
 func TestThoughtResponseJSONShape(t *testing.T) {
 	resp := ThoughtResponse{
-		ThoughtNumber:        1,
-		TotalThoughts:        3,
-		NextThoughtNeeded:    true,
 		Branches:             []string{},
 		ThoughtHistoryLength: 1,
 		SessionConfidence:    0.6,
@@ -58,9 +55,14 @@ func TestThoughtResponseJSONShape(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	for _, key := range []string{"thoughtNumber", "totalThoughts", "nextThoughtNeeded", "branches", "thoughtHistoryLength", "sessionConfidence"} {
+	for _, key := range []string{"branches", "thoughtHistoryLength", "sessionConfidence"} {
 		if _, ok := got[key]; !ok {
 			t.Errorf("missing key: %s", key)
+		}
+	}
+	for _, key := range []string{"thoughtNumber", "totalThoughts", "nextThoughtNeeded"} {
+		if _, ok := got[key]; ok {
+			t.Errorf("response should not echo %s (caller already has it)", key)
 		}
 	}
 	if _, ok := got["branchConfidences"]; ok {
@@ -76,8 +78,8 @@ func intPtr(i int) *int    { return &i }
 func validBase() ThoughtData {
 	return ThoughtData{
 		Thought:           "a thought",
-		ThoughtNumber:     1,
-		TotalThoughts:     1,
+		ThoughtNumber:     intPtr(1),
+		TotalThoughts:     intPtr(1),
 		NextThoughtNeeded: boolPtr(false),
 		Confidence:        0.5,
 		Assumptions:       []string{},
@@ -93,9 +95,9 @@ func TestValidateRequiredFields(t *testing.T) {
 		wantErr string
 	}{
 		{"empty thought", func(td *ThoughtData) { td.Thought = "" }, "thought must be a non-empty string"},
-		{"zero thoughtNumber", func(td *ThoughtData) { td.ThoughtNumber = 0 }, "thoughtNumber must be ≥ 1"},
-		{"negative thoughtNumber", func(td *ThoughtData) { td.ThoughtNumber = -1 }, "thoughtNumber must be ≥ 1"},
-		{"zero totalThoughts", func(td *ThoughtData) { td.TotalThoughts = 0 }, "totalThoughts must be ≥ 1"},
+		{"zero thoughtNumber", func(td *ThoughtData) { td.ThoughtNumber = intPtr(0) }, "thoughtNumber must be ≥ 1"},
+		{"negative thoughtNumber", func(td *ThoughtData) { td.ThoughtNumber = intPtr(-1) }, "thoughtNumber must be ≥ 1"},
+		{"zero totalThoughts", func(td *ThoughtData) { td.TotalThoughts = intPtr(0) }, "totalThoughts must be ≥ 1"},
 		{"missing nextThoughtNeeded", func(td *ThoughtData) { td.NextThoughtNeeded = nil }, "nextThoughtNeeded must be present"},
 		{"empty critique", func(td *ThoughtData) { td.Critique = "" }, "critique must be a non-empty string"},
 		{"empty counterArgument", func(td *ThoughtData) { td.CounterArgument = "" }, "counterArgument must be a non-empty string"},

--- a/internal/thinking/schema_test.go
+++ b/internal/thinking/schema_test.go
@@ -2,6 +2,7 @@ package thinking
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -189,6 +190,90 @@ func TestValidateConditionalNextStepRationale(t *testing.T) {
 		td.NextStepRationale = ""
 		if err := td.Validate(); err != nil {
 			t.Errorf("nextStepRationale empty should be OK when nextThoughtNeeded=false, got: %v", err)
+		}
+	})
+}
+
+func TestValidateLengthCaps(t *testing.T) {
+	t.Run("critique at cap is allowed", func(t *testing.T) {
+		td := validBase()
+		td.Critique = strings.Repeat("x", maxCritiqueLen)
+		if err := td.Validate(); err != nil {
+			t.Errorf("critique at cap should validate, got: %v", err)
+		}
+	})
+	t.Run("critique over cap rejected", func(t *testing.T) {
+		td := validBase()
+		td.Critique = strings.Repeat("x", maxCritiqueLen+1)
+		err := td.Validate()
+		if err == nil || !contains(err.Error(), "critique must be ≤") {
+			t.Errorf("expected critique length error, got %v", err)
+		}
+	})
+	t.Run("counterArgument at cap is allowed", func(t *testing.T) {
+		td := validBase()
+		td.CounterArgument = strings.Repeat("x", maxCounterArgumentLen)
+		if err := td.Validate(); err != nil {
+			t.Errorf("counterArgument at cap should validate, got: %v", err)
+		}
+	})
+	t.Run("counterArgument over cap rejected", func(t *testing.T) {
+		td := validBase()
+		td.CounterArgument = strings.Repeat("x", maxCounterArgumentLen+1)
+		err := td.Validate()
+		if err == nil || !contains(err.Error(), "counterArgument must be ≤") {
+			t.Errorf("expected counterArgument length error, got %v", err)
+		}
+	})
+	t.Run("assumption entry at cap is allowed", func(t *testing.T) {
+		td := validBase()
+		td.Assumptions = []string{strings.Repeat("x", maxAssumptionLen)}
+		if err := td.Validate(); err != nil {
+			t.Errorf("assumption at cap should validate, got: %v", err)
+		}
+	})
+	t.Run("assumption entry over cap rejected", func(t *testing.T) {
+		td := validBase()
+		td.Assumptions = []string{"ok", strings.Repeat("x", maxAssumptionLen+1)}
+		err := td.Validate()
+		if err == nil || !contains(err.Error(), "assumptions[1] must be ≤") {
+			t.Errorf("expected assumption length error, got %v", err)
+		}
+	})
+	t.Run("nextStepRationale over cap rejected when needed", func(t *testing.T) {
+		td := validBase()
+		td.NextThoughtNeeded = boolPtr(true)
+		td.NextStepRationale = strings.Repeat("x", maxNextStepRationaleLen+1)
+		err := td.Validate()
+		if err == nil || !contains(err.Error(), "nextStepRationale must be ≤") {
+			t.Errorf("expected nextStepRationale length error, got %v", err)
+		}
+	})
+	t.Run("nextStepRationale length not enforced when not needed", func(t *testing.T) {
+		// When nextThoughtNeeded=false, the field is logically absent and any
+		// stale value is benign — no length check.
+		td := validBase()
+		td.NextThoughtNeeded = boolPtr(false)
+		td.NextStepRationale = strings.Repeat("x", maxNextStepRationaleLen+500)
+		if err := td.Validate(); err != nil {
+			t.Errorf("nextStepRationale length should not fire when nextThoughtNeeded=false, got: %v", err)
+		}
+	})
+	t.Run("rune-counted not byte-counted", func(t *testing.T) {
+		// 200 em-dashes (each 3 bytes in UTF-8, 1 rune). Should be rejected
+		// for nextStepRationale (cap 200) only because we go one rune over.
+		td := validBase()
+		td.NextThoughtNeeded = boolPtr(true)
+		td.NextStepRationale = ""
+		for range maxNextStepRationaleLen {
+			td.NextStepRationale += "—"
+		}
+		if err := td.Validate(); err != nil {
+			t.Errorf("exactly cap runes should validate, got: %v", err)
+		}
+		td.NextStepRationale += "—"
+		if err := td.Validate(); err == nil {
+			t.Errorf("one rune over cap should be rejected")
 		}
 	})
 }

--- a/internal/thinking/server.go
+++ b/internal/thinking/server.go
@@ -2,6 +2,7 @@ package thinking
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -96,8 +97,42 @@ func (s *SequentialThinkingServer) ProcessThought(td ThoughtData) (ToolResult, e
 			*td.BranchFromThought, len(s.thoughtHistory))), nil
 	}
 
-	if td.ThoughtNumber > td.TotalThoughts {
-		td.TotalThoughts = td.ThoughtNumber
+	// Auto-assign ThoughtNumber when omitted: branch thoughts get the next
+	// position within their branch; everything else gets the next trunk slot.
+	if td.ThoughtNumber == nil {
+		var n int
+		if td.BranchFromThought != nil && td.BranchID != "" {
+			n = len(s.branches[td.BranchID]) + 1
+		} else {
+			n = len(s.thoughtHistory) + 1
+		}
+		td.ThoughtNumber = &n
+	}
+
+	// Inherit TotalThoughts from the most recent trunk thought when omitted.
+	// Walking the log backwards filters out branch thoughts so the trunk's
+	// running total isn't contaminated by a branch's auto-bumped value.
+	// First call (no trunk thoughts yet) must send it explicitly — there is
+	// nothing to inherit.
+	if td.TotalThoughts == nil {
+		var inherited *int
+		for i := len(s.thoughtHistory) - 1; i >= 0; i-- {
+			h := s.thoughtHistory[i]
+			if h.BranchFromThought == nil && h.BranchID == "" {
+				inherited = h.TotalThoughts
+				break
+			}
+		}
+		if inherited == nil {
+			return errorResult(errors.New("totalThoughts is required on the first trunk thought of a session (no prior trunk value to inherit)")), nil
+		}
+		v := *inherited
+		td.TotalThoughts = &v
+	}
+
+	if *td.ThoughtNumber > *td.TotalThoughts {
+		v := *td.ThoughtNumber
+		td.TotalThoughts = &v
 	}
 
 	s.thoughtHistory = append(s.thoughtHistory, td)
@@ -130,9 +165,6 @@ func (s *SequentialThinkingServer) ProcessThought(td ThoughtData) (ToolResult, e
 	}
 
 	resp := ThoughtResponse{
-		ThoughtNumber:        td.ThoughtNumber,
-		TotalThoughts:        td.TotalThoughts,
-		NextThoughtNeeded:    *td.NextThoughtNeeded,
 		Branches:             sortedKeys(s.branches),
 		ThoughtHistoryLength: len(s.thoughtHistory),
 		SessionConfidence:    sessionConf,
@@ -192,7 +224,7 @@ func (s *SequentialThinkingServer) headerLineLocked(td ThoughtData) string {
 	switch {
 	case td.IsRevision != nil && *td.IsRevision && td.RevisesThought != nil:
 		return fmt.Sprintf("Revision of thought %d (now thought %d) · confidence %.2f",
-			*td.RevisesThought, td.ThoughtNumber, td.Confidence)
+			*td.RevisesThought, *td.ThoughtNumber, td.Confidence)
 	case td.BranchFromThought != nil && td.BranchID != "":
 		// First-in-branch vs subsequent: count the current branch's depth.
 		// At this point the new thought has already been appended to s.branches[BranchID].
@@ -202,10 +234,10 @@ func (s *SequentialThinkingServer) headerLineLocked(td ThoughtData) string {
 				td.BranchID, *td.BranchFromThought, td.Confidence)
 		}
 		return fmt.Sprintf("Branch '%s' · thought %d · confidence %.2f",
-			td.BranchID, td.ThoughtNumber, td.Confidence)
+			td.BranchID, *td.ThoughtNumber, td.Confidence)
 	default:
 		return fmt.Sprintf("Thought %d of %d · confidence %.2f",
-			td.ThoughtNumber, td.TotalThoughts, td.Confidence)
+			*td.ThoughtNumber, *td.TotalThoughts, td.Confidence)
 	}
 }
 

--- a/internal/thinking/server_test.go
+++ b/internal/thinking/server_test.go
@@ -27,8 +27,8 @@ func TestNewServerStartsEmpty(t *testing.T) {
 func validInput(num int) ThoughtData {
 	return ThoughtData{
 		Thought:           "thought number " + strconv.Itoa(num),
-		ThoughtNumber:     num,
-		TotalThoughts:     3,
+		ThoughtNumber:     intPtr(num),
+		TotalThoughts:     intPtr(3),
 		NextThoughtNeeded: boolPtr(true),
 		Confidence:        0.5,
 		Assumptions:       []string{},
@@ -55,26 +55,171 @@ func TestProcessThoughtAppendsHistory(t *testing.T) {
 	if err := json.Unmarshal([]byte(res.StructuredJSON), &resp); err != nil {
 		t.Fatalf("unmarshal structured: %v", err)
 	}
-	if resp.ThoughtNumber != 1 {
-		t.Errorf("response.ThoughtNumber = %d, want 1", resp.ThoughtNumber)
-	}
 	if resp.ThoughtHistoryLength != 1 {
 		t.Errorf("response.ThoughtHistoryLength = %d, want 1", resp.ThoughtHistoryLength)
+	}
+	// The response no longer echoes thoughtNumber/totalThoughts/nextThoughtNeeded
+	// (caller already has them). Verify the value via the persisted history.
+	snap := s.Snapshot()
+	if got := *snap.Thoughts[0].ThoughtNumber; got != 1 {
+		t.Errorf("snapshot thoughtNumber = %d, want 1", got)
+	}
+}
+
+func TestProcessThoughtAutoAssignsThoughtNumber(t *testing.T) {
+	s := NewServer()
+	for i := 1; i <= 3; i++ {
+		td := validInput(i)
+		td.ThoughtNumber = nil // omit — server should fill in
+		if _, err := s.ProcessThought(td); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	snap := s.Snapshot()
+	if got := len(snap.Thoughts); got != 3 {
+		t.Fatalf("history length = %d, want 3", got)
+	}
+	for i, th := range snap.Thoughts {
+		if got := *th.ThoughtNumber; got != i+1 {
+			t.Errorf("thought %d auto-assigned %d, want %d", i, got, i+1)
+		}
+	}
+}
+
+func TestProcessThoughtInheritsTotalThoughts(t *testing.T) {
+	s := NewServer()
+	first := validInput(1)
+	first.TotalThoughts = intPtr(7)
+	if _, err := s.ProcessThought(first); err != nil {
+		t.Fatal(err)
+	}
+	second := validInput(2)
+	second.TotalThoughts = nil // omit — should inherit 7
+	if _, err := s.ProcessThought(second); err != nil {
+		t.Fatal(err)
+	}
+	snap := s.Snapshot()
+	if got := *snap.Thoughts[1].TotalThoughts; got != 7 {
+		t.Errorf("totalThoughts not inherited: got %d, want 7", got)
+	}
+}
+
+func TestProcessThoughtAutoAssignsBranchThoughtNumber(t *testing.T) {
+	s := NewServer()
+	if _, err := s.ProcessThought(validInput(1)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.ProcessThought(validInput(2)); err != nil {
+		t.Fatal(err)
+	}
+	// First branch thought, omitted thoughtNumber → expect within-branch depth = 1.
+	first := validInput(0)
+	first.ThoughtNumber = nil
+	first.BranchFromThought = intPtr(2)
+	first.BranchID = "alt"
+	if _, err := s.ProcessThought(first); err != nil {
+		t.Fatal(err)
+	}
+	// Second branch thought, also omitted → expect 2.
+	second := validInput(0)
+	second.ThoughtNumber = nil
+	second.BranchFromThought = intPtr(2)
+	second.BranchID = "alt"
+	if _, err := s.ProcessThought(second); err != nil {
+		t.Fatal(err)
+	}
+	snap := s.Snapshot()
+	got := snap.Branches["alt"]
+	if len(got) != 2 {
+		t.Fatalf("branch alt length = %d, want 2", len(got))
+	}
+	if n := *got[0].ThoughtNumber; n != 1 {
+		t.Errorf("first branch thought auto-assigned %d, want 1", n)
+	}
+	if n := *got[1].ThoughtNumber; n != 2 {
+		t.Errorf("second branch thought auto-assigned %d, want 2", n)
+	}
+}
+
+func TestProcessThoughtAutoAssignsRevisionThoughtNumber(t *testing.T) {
+	s := NewServer()
+	for i := 1; i <= 3; i++ {
+		if _, err := s.ProcessThought(validInput(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Revising thought 2; omit thoughtNumber → server fills in next trunk slot (4).
+	rev := validInput(0)
+	rev.ThoughtNumber = nil
+	rev.IsRevision = boolPtr(true)
+	rev.RevisesThought = intPtr(2)
+	if _, err := s.ProcessThought(rev); err != nil {
+		t.Fatal(err)
+	}
+	snap := s.Snapshot()
+	if got := *snap.Thoughts[3].ThoughtNumber; got != 4 {
+		t.Errorf("revision auto-assigned %d, want 4 (next trunk slot)", got)
+	}
+}
+
+func TestProcessThoughtInheritanceSkipsBranchThoughts(t *testing.T) {
+	// Regression: inheritance must walk back to the last *trunk* thought, not
+	// the most recent thought of any kind. A branch thought with an
+	// auto-bumped TotalThoughts should not contaminate the trunk's value.
+	s := NewServer()
+	first := validInput(1)
+	first.TotalThoughts = intPtr(5)
+	if _, err := s.ProcessThought(first); err != nil {
+		t.Fatal(err)
+	}
+	// Branch thought with explicit thoughtNumber > totalThoughts → server
+	// auto-bumps the stored TotalThoughts on the branch thought to 99.
+	branch := validInput(99)
+	branch.TotalThoughts = intPtr(5)
+	branch.BranchFromThought = intPtr(1)
+	branch.BranchID = "alt"
+	if _, err := s.ProcessThought(branch); err != nil {
+		t.Fatal(err)
+	}
+	// Resume trunk with omitted totalThoughts → must inherit 5 (from the
+	// last trunk thought), NOT 99 (from the branch thought).
+	resume := validInput(2)
+	resume.TotalThoughts = nil
+	if _, err := s.ProcessThought(resume); err != nil {
+		t.Fatal(err)
+	}
+	snap := s.Snapshot()
+	if got := *snap.Thoughts[2].TotalThoughts; got != 5 {
+		t.Errorf("inheritance contaminated by branch: got %d, want 5", got)
+	}
+}
+
+func TestProcessThoughtFirstThoughtRequiresTotalThoughts(t *testing.T) {
+	s := NewServer()
+	td := validInput(1)
+	td.TotalThoughts = nil // omit on first call — must error
+	res, err := s.ProcessThought(td)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError=true when totalThoughts is omitted on first thought")
+	}
+	if got := s.HistoryLength(); got != 0 {
+		t.Errorf("first-thought failure should not mutate state, HistoryLength=%d", got)
 	}
 }
 
 func TestProcessThoughtAutoBumpsTotalThoughts(t *testing.T) {
 	s := NewServer()
 	td := validInput(5)
-	td.TotalThoughts = 3 // less than ThoughtNumber
-	res, err := s.ProcessThought(td)
-	if err != nil {
+	td.TotalThoughts = intPtr(3) // less than ThoughtNumber
+	if _, err := s.ProcessThought(td); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var resp ThoughtResponse
-	_ = json.Unmarshal([]byte(res.StructuredJSON), &resp)
-	if resp.TotalThoughts != 5 {
-		t.Errorf("totalThoughts not auto-bumped: got %d, want 5", resp.TotalThoughts)
+	snap := s.Snapshot()
+	if got := *snap.Thoughts[0].TotalThoughts; got != 5 {
+		t.Errorf("totalThoughts not auto-bumped: got %d, want 5", got)
 	}
 }
 
@@ -327,7 +472,7 @@ func TestProcessThoughtConcurrent(t *testing.T) {
 			defer wg.Done()
 			for i := 0; i < perGoroutine; i++ {
 				td := validInput(gID*perGoroutine + i + 1)
-				td.TotalThoughts = goroutines * perGoroutine
+				td.TotalThoughts = intPtr(goroutines * perGoroutine)
 				if _, err := s.ProcessThought(td); err != nil {
 					t.Errorf("goroutine %d iter %d: %v", gID, i, err)
 					return

--- a/main_test.go
+++ b/main_test.go
@@ -231,10 +231,11 @@ func extractFirstJSON(body string) string {
 // defined here to avoid importing test-only helpers across packages.
 func validInputN(num int, sessionTag string) thinking.ThoughtData {
 	yes := true
+	tot := 20
 	return thinking.ThoughtData{
 		Thought:           sessionTag + " thought " + strconv.Itoa(num),
-		ThoughtNumber:     num,
-		TotalThoughts:     20,
+		ThoughtNumber:     &num,
+		TotalThoughts:     &tot,
 		NextThoughtNeeded: &yes,
 		Confidence:        0.5,
 		Assumptions:       []string{},


### PR DESCRIPTION
## Summary

Three focused commits that cut per-MCP-call token cost ~47% on a representative 3-thought session, while preserving the four-field critical-thinking discipline (confidence, assumptions, critique, counterArgument) and adding richer client-facing field documentation.

- **`0723ab8` — Length caps + tightened critical-field voice.** Server-side rune-counted `maxLength` enforcement in `Validate()` (critique 280, counterArgument 280, per-assumption 200, nextStepRationale 200, gated on `nextThoughtNeeded=true`). Description guidance updated to "one tight sentence each."
- **`c987f05` — Wire-format trims (T2/T4/T5).** `ThoughtResponse` no longer echoes `thoughtNumber`/`totalThoughts`/`nextThoughtNeeded` (caller already sent them). `ThoughtNumber` and `TotalThoughts` are now `*int`: omit `thoughtNumber` to auto-assign (trunk: history+1; branch: branch-depth); omit `totalThoughts` to inherit the most recent **trunk** thought's value (branch thoughts deliberately don't contaminate inheritance). First trunk thought of a session must still send `totalThoughts`.
- **`649e0f4` — Restored structural-field docs.** Per-field semantics for `isRevision`/`revisesThought`/`branchFromThought`/`branchId`/`needsMoreThoughts`/`nextThoughtNeeded` were thin in the previous description; re-introduced them along with explicit "When to use this tool" and "Process guidance" sections drawn from the upstream `sequential-thinking` description.

## Token-cost measurements (tiktoken `cl100k_base`, Prompt B 3-thought session)

| Stage | Per-session tokens | vs original |
|---|---:|---:|
| Pre-tightening (origin/feat/rubber-ducky-mcp) | 1,042 | — |
| Post-tightening (`0723ab8`) | 629 | -39.6% |
| Post + T2/T4/T5 (`c987f05`) | 551 | -47.1% |

Tool description grew from 939 → 1,593 tokens across the three commits. With prompt caching, the description cost amortizes; without caching, break-even vs the original is at ~4 tool calls per session and savings compound thereafter (e.g., -976 tok at 10 calls, -7,496 tok at 50 calls).

## Migration notes (in README)

- New length caps return `IsError: true` for over-cap fields. Caps are rune-counted (multi-byte safe).
- `thoughtNumber` and `totalThoughts` now optional after the first trunk thought; first trunk thought must include `totalThoughts`.
- Auto-assigned branch `thoughtNumber` is **branch-depth**, not a global ordinal — clients that store it as a global ordinal should keep sending it explicitly.
- Response no longer includes `thoughtNumber`/`totalThoughts`/`nextThoughtNeeded`. Read the full per-thought state from the `thinking://current` resource if needed.

## Test plan

- [x] `go test -race -count=1 ./...` — green
- [x] `go vet ./...` — clean
- [x] `gofmt -d .` — clean
- [x] Two independent code reviews (cold, no shared context) on the diff — concerns addressed:
  - Inheritance now skips branch thoughts (regression locked in by `TestProcessThoughtInheritanceSkipsBranchThoughts`)
  - Branch and revision auto-assign paths covered by new tests
  - Error message clarified for first-thought required totalThoughts
- [ ] Reviewer should validate the README migration note covers the auto-assigned-thoughtNumber semantic if any downstream client relies on global ordinals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)