### PR TITLE
docs: restructure README ≤120 lines, split detail into docs/, rename binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,12 @@ COPY . .
 RUN CGO_ENABLED=0 go build \
     -trimpath \
     -ldflags "-s -w -X main.version=${VERSION}" \
-    -o /out/rubber-ducky-thinking .
+    -o /out/rubber-ducky-mcp .
 
 # ---- final ----
 FROM gcr.io/distroless/static-debian12:nonroot AS release
 
-COPY --from=builder /out/rubber-ducky-thinking /rubber-ducky-thinking
+COPY --from=builder /out/rubber-ducky-mcp /rubber-ducky-mcp
 
 LABEL org.opencontainers.image.title="Rubber Ducky MCP"
 LABEL org.opencontainers.image.description="MCP server for critical, narrated, sequential thinking"
@@ -39,5 +39,5 @@ EXPOSE 3000
 # /health from the network. No HEALTHCHECK directive in the image.
 
 USER nonroot:nonroot
-ENTRYPOINT ["/rubber-ducky-thinking"]
+ENTRYPOINT ["/rubber-ducky-mcp"]
 CMD ["-http", ":3000"]

--- a/README.md
+++ b/README.md
@@ -1,82 +1,97 @@
 # Rubber Ducky MCP
 
-A Model Context Protocol server for **critical, narrated, sequential thinking**. A rubber duck you talk to while you think, one step at a time, with required confidence calibration and adversarial self-critique on every thought.
+A Model Context Protocol server for **critical, narrated, sequential thinking**. A rubber duck you talk to while you think — one step at a time — with required confidence calibration and adversarial self-critique on every thought.
 
-This server fuses three disciplines:
+It fuses three disciplines:
 
 1. **Sequential thinking** — break problems into ordered, numbered steps; revise; branch.
 2. **Rubber-duck narration** — explain each thought out loud, in first-person, to an imagined listener.
 3. **Critical self-examination** — every thought is paired with confidence, assumptions, critique, and a counter-argument.
 
-The single tool is `criticalthinking`. Every call must include the critical-thinking fields — there is no opt-out, by design. See the tool description for the full contract.
+The single tool is `criticalthinking`. Every call must include the four critical-thinking fields — there is no opt-out, by design.
 
 ## Install
 
-### Go
-
 ```bash
 go install github.com/jacaudi/rubber-ducky-mcp@latest
-# binary lands at $GOPATH/bin/rubber-ducky-mcp
+# or
+docker pull ghcr.io/jacaudi/rubber-ducky-mcp:latest
 ```
 
-### Docker
-
-```bash
-docker run --rm -p 3000:3000 ghcr.io/jacaudi/rubber-ducky-mcp:latest
-```
+The Go install lands the binary at `$GOPATH/bin/rubber-ducky-mcp`.
 
 ## Run
 
-### Stdio (default)
-
 ```bash
-rubber-ducky-thinking
+# stdio (default; for Claude Desktop, Codex CLI, VS Code, etc.)
+rubber-ducky-mcp
+
+# Streamable HTTP
+rubber-ducky-mcp -http :3000
+
+# Docker (HTTP on :3000)
+docker run --rm -p 3000:3000 ghcr.io/jacaudi/rubber-ducky-mcp:latest
 ```
 
-Use this for direct integration with MCP hosts (Claude Desktop, Codex CLI, VS Code).
+## One-call example
 
-### Streamable HTTP
+Request:
 
-```bash
-rubber-ducky-thinking -http :3000
+```json
+{
+  "thought": "I think we should normalize first because reads dominate writes.",
+  "thoughtNumber": 1, "totalThoughts": 3, "nextThoughtNeeded": true,
+  "confidence": 0.6,
+  "assumptions": ["read:write ratio is ~10:1"],
+  "critique": "Drifted into solution mode without confirming the ratio.",
+  "counterArgument": "If writes dominate, monolith-first is simpler.",
+  "nextStepRationale": "Verify the read:write ratio before committing to normalization."
+}
 ```
 
-Endpoints:
+Response (`structuredContent`):
 
-- `POST/GET/DELETE /mcp` — main MCP endpoint.
-- `GET /health` — `{status, transport, sessionsCreated, version}`. `sessionsCreated` is a lifetime counter of sessions ever created in this process; it is NOT pruned when the SDK closes idle sessions.
-
-## Configuration
-
-| Env var | Default | Purpose |
-|---|---|---|
-| `ALLOWED_ORIGINS` | (empty) | Comma-separated list of browser origins permitted to call `/mcp`. Wired into both the outer CORS layer and the SDK's CSRF protection (`http.CrossOriginProtection.AddTrustedOrigin`). Default rejects all browser origins. Non-browser callers (no `Origin` / no `Sec-Fetch-Site` header) are unaffected. |
-| `DOCKER` | unset | When `true`, HTTP server binds to `0.0.0.0` instead of `127.0.0.1`. Set automatically in the published Docker image. |
-| `DISABLE_THOUGHT_LOGGING` | unset | Reserved for the future structured-log gate. The current server emits no per-thought logs by default. |
-
-Sessions are in-memory only; idle sessions expire after 1 hour (enforced by the SDK via `StreamableHTTPOptions.SessionTimeout`).
-
-## Migrating from `http-sequential-thinking`
-
-This is the Go successor to `jacaudi/http-sequential-thinking`. Breaking changes:
-
-- **Tool renamed:** `sequentialthinking` → `criticalthinking`. Update `mcp.json` references.
-- **Required new fields:** every call must send `confidence`, `assumptions`, `critique`, `counterArgument`. Calls missing these fail with `IsError: true`.
-- **`nextStepRationale` required when `nextThoughtNeeded: true`.**
-- **Binary renamed:** `http-sequential-thinking` → `rubber-ducky-thinking`. Update `mcp.json` `command` fields and any shell-script references.
-- **Server name renamed:** `sequential-thinking-server` → `rubber-ducky-thinking`.
-- **Web UI removed.** Use MCP Inspector or `curl` for manual testing.
-- **CORS default tightened.** Set `ALLOWED_ORIGINS` explicitly to allow browser clients.
-
-## Development
-
-```bash
-go test -race ./...
-go vet ./...
-gofmt -d .
-go build -ldflags "-X main.version=$(git describe --tags --always)" -o rubber-ducky-thinking .
+```json
+{ "branches": [], "thoughtHistoryLength": 1, "sessionConfidence": 0.6 }
 ```
+
+The `text` content is a rendered transcript in rubber-duck voice. Subsequent calls can omit `thoughtNumber` (auto-assigned) and `totalThoughts` (inherited). Every critical-thinking field has a server-side length cap to enforce one-tight-sentence discipline. The full contract lives in the tool description itself.
+
+## Client setup
+
+`mcp.json` (Claude Desktop / Codex CLI / VS Code):
+
+```json
+{
+  "mcpServers": {
+    "rubber-ducky": { "command": "rubber-ducky-mcp" }
+  }
+}
+```
+
+Or HTTP:
+
+```json
+{
+  "mcpServers": {
+    "rubber-ducky": { "url": "http://localhost:3000/mcp" }
+  }
+}
+```
+
+More client recipes in [docs/clients.md](docs/clients.md).
+
+## Resources
+
+The server exposes `thinking://current` — a per-session JSON snapshot of the full thought history (trunk + branches, all critical-thinking fields preserved).
+
+## Documentation
+
+- [docs/configuration.md](docs/configuration.md) — env vars, HTTP endpoints, session lifecycle
+- [docs/clients.md](docs/clients.md) — Claude Desktop, Codex CLI, VS Code, Cursor recipes
+- [docs/development.md](docs/development.md) — building, testing, debugging with MCP Inspector
+- [docs/migration.md](docs/migration.md) — breaking changes since `http-sequential-thinking`
 
 ## License
 
-MIT.
+[MIT](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,12 @@
+# Documentation
+
+Reference material for `rubber-ducky-mcp`. The top-level [README](../README.md) is the landing page; everything below is detail.
+
+| File | Covers |
+|---|---|
+| [configuration.md](configuration.md) | Env vars (`ALLOWED_ORIGINS`, `DOCKER`, `DISABLE_THOUGHT_LOGGING`), HTTP endpoints, session lifecycle, idle timeout |
+| [clients.md](clients.md) | `mcp.json` snippets for Claude Desktop, Codex CLI, VS Code, Cursor — both stdio and HTTP transports |
+| [development.md](development.md) | Building, running tests with `-race`, debugging with MCP Inspector, release workflow |
+| [migration.md](migration.md) | Cumulative breaking-change log since the `http-sequential-thinking` Node predecessor |
+
+For the tool's full input contract (every field, every length cap, every rule), read the tool description itself — clients receive it on `tools/list`. Code lives in [`internal/thinking/description.go`](../internal/thinking/description.go).

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,0 +1,91 @@
+# Client setup
+
+All snippets assume the binary `rubber-ducky-mcp` is on your `$PATH`. After `go install github.com/jacaudi/rubber-ducky-mcp@latest`, that's `$GOPATH/bin/rubber-ducky-mcp` — make sure `$GOPATH/bin` is on `$PATH`, or use the absolute path in the `command` field.
+
+## Claude Desktop
+
+`~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "rubber-ducky": {
+      "command": "rubber-ducky-mcp"
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing.
+
+## Codex CLI
+
+`~/.codex/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rubber-ducky": {
+      "command": "rubber-ducky-mcp"
+    }
+  }
+}
+```
+
+## VS Code (Continue, Cline, etc.)
+
+Most VS Code MCP-aware extensions use the same `mcp.json` shape:
+
+```json
+{
+  "mcpServers": {
+    "rubber-ducky": {
+      "command": "rubber-ducky-mcp"
+    }
+  }
+}
+```
+
+## Cursor
+
+`~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "rubber-ducky": {
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+(Cursor currently prefers HTTP transport.) Run the server separately with `rubber-ducky-mcp -http :3000`.
+
+## Generic HTTP (any client)
+
+Run the server in HTTP mode and point your client at `/mcp`:
+
+```bash
+rubber-ducky-mcp -http :3000
+```
+
+```json
+{
+  "mcpServers": {
+    "rubber-ducky": {
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+For browser-based clients, set `ALLOWED_ORIGINS` to permit your origin — see [configuration.md](configuration.md).
+
+## Docker
+
+```bash
+docker run -d --name rubber-ducky -p 3000:3000 ghcr.io/jacaudi/rubber-ducky-mcp:latest
+```
+
+Then use the HTTP client config above. The image binds to `0.0.0.0` automatically (via `DOCKER=true`); pair it with appropriate firewall rules in production.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,46 @@
+# Configuration
+
+## Environment variables
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `ALLOWED_ORIGINS` | (empty) | Comma-separated list of browser origins permitted to call `/mcp`. Wired into both the outer CORS layer and the SDK's CSRF protection (`http.CrossOriginProtection.AddTrustedOrigin`). Default rejects all browser origins. Non-browser callers (no `Origin` / no `Sec-Fetch-Site` header) are unaffected. |
+| `DOCKER` | unset | When `true`, HTTP server binds to `0.0.0.0` instead of `127.0.0.1`. Set automatically in the published Docker image. |
+| `DISABLE_THOUGHT_LOGGING` | unset | Reserved for the future structured-log gate. The current server emits no per-thought logs by default. |
+
+## Transports
+
+### Stdio (default)
+
+```bash
+rubber-ducky-mcp
+```
+
+One process serves one session. There is no cross-stream isolation concern because there is no second stream — the process IS the session. Use this for direct integration with MCP hosts (Claude Desktop, Codex CLI, VS Code).
+
+### Streamable HTTP
+
+```bash
+rubber-ducky-mcp -http :3000
+```
+
+The HTTP server binds to `127.0.0.1` by default (or `0.0.0.0` when `DOCKER=true`). Each session gets its own `*mcp.Server` with its own `SequentialThinkingServer`, constructed inside a factory closure — there is no map keyed by session ID anywhere, by design. The closure scope is the cross-session isolation invariant.
+
+## HTTP endpoints
+
+| Path | Methods | Purpose |
+|---|---|---|
+| `/mcp` | `POST`, `GET`, `DELETE` | Main MCP endpoint (Streamable HTTP) |
+| `/health` | `GET` | Returns `{status, transport, sessionsCreated, version}`. `sessionsCreated` is a **lifetime** counter of sessions ever created in this process; it is NOT pruned when the SDK closes idle sessions. Treat it as a creation counter, not an active-session gauge. |
+
+## Session lifecycle
+
+Sessions are in-memory only. Idle sessions expire after **1 hour**, enforced by the SDK via `StreamableHTTPOptions.SessionTimeout`. When the SDK closes a session, the bound `*mcp.Server` (and the `*SequentialThinkingServer` it captures) becomes unreachable and is released for GC.
+
+There is no callback fired when the SDK closes a session, so the in-process registry that powers `/health.sessionsCreated` drifts upward — that's intentional. If you need an accurate active-session count, get it from your reverse proxy or load balancer, not from this server.
+
+## CORS and CSRF
+
+When `ALLOWED_ORIGINS` is empty, browser requests with an `Origin` header are rejected with HTTP 403. Non-browser clients (no `Origin`, no `Sec-Fetch-Site`) bypass the check entirely. When set, matching origins receive `Access-Control-Allow-Origin: <origin>`, `Access-Control-Allow-Credentials: true`, `Access-Control-Expose-Headers: mcp-session-id`, and a `Vary: Origin` header for cache-poisoning mitigation.
+
+The same origin list is registered with the SDK's CSRF protection (`http.CrossOriginProtection.AddTrustedOrigin`) so the SDK's same-origin policy doesn't double-reject permitted browser callers.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,63 @@
+# Development
+
+## Toolchain
+
+Go 1.26+. No other build dependencies (the MCP SDK is a Go module).
+
+## Build
+
+```bash
+go build -ldflags "-X main.version=$(git describe --tags --always)" -o rubber-ducky-mcp .
+```
+
+The `-X main.version=...` flag stamps the build with a version string surfaced via `/health` and the MCP `Implementation.Version`.
+
+## Test
+
+```bash
+go test -race -count=1 ./...   # full suite, race detector on, no test cache
+go vet ./...                    # static checks
+gofmt -d .                      # diff against gofmt; empty output = clean
+```
+
+`-race` is the standard mode for this project. Concurrency invariants in the HTTP path are non-trivial (per-session factory closures, session registry mutex) and `go test` without `-race` will not catch their regressions.
+
+## Debugging with MCP Inspector
+
+The fastest way to manually exercise the tool is the official [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+```bash
+# stdio
+npx @modelcontextprotocol/inspector rubber-ducky-mcp
+
+# HTTP
+rubber-ducky-mcp -http :3000 &
+npx @modelcontextprotocol/inspector --uri http://localhost:3000/mcp
+```
+
+The inspector lets you call `criticalthinking` interactively, watch the rendered transcript, and read the `thinking://current` resource without writing client code.
+
+## Project layout
+
+```
+.
+├── main.go                       # MCP transport adapter (stdio + HTTP)
+├── main_test.go                  # cross-session isolation integration test
+├── internal/thinking/
+│   ├── description.go            # tool description (the prompt-engineering contract)
+│   ├── schema.go                 # ThoughtData / ThoughtResponse + Validate()
+│   ├── server.go                 # SequentialThinkingServer state machine
+│   └── *_test.go                 # unit tests
+├── Dockerfile                    # multi-stage, distroless final
+└── docker-bake.hcl               # buildx bake config
+```
+
+The `internal/thinking` package has zero dependency on the MCP SDK — `main.go` is the only adapter. That keeps the state machine fully unit-testable.
+
+## Release workflow
+
+CI runs on push and PR via GitHub Actions: `vet`, `gofmt`, `go test -race -count=1 ./...`, and a Docker build. Releases are tag-driven; tagging `vX.Y.Z` triggers the release workflow which builds and pushes the multi-arch Docker image to `ghcr.io/jacaudi/rubber-ducky-mcp:vX.Y.Z` and updates `:latest`.
+
+## Treating the description as a protocol
+
+The string in [`internal/thinking/description.go`](../internal/thinking/description.go) is the contract every client agent reads. Treat changes there like wire-format changes: bump the package version and add an entry to [migration.md](migration.md). Field renames, length-cap changes, or removed guidance can all silently break agent behavior.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,59 @@
+# Migration
+
+Cumulative breaking-change log for `rubber-ducky-mcp`. Most recent changes first.
+
+## From `0.6.x` (post-rewrite, prior to length-cap and optional-field work)
+
+### Length caps on critical fields
+
+Server-side rune-counted maxLength on the four critical-thinking fields. Over-cap requests return `IsError: true`.
+
+| Field | Cap (runes) | Notes |
+|---|---:|---|
+| `critique` | 280 | Always enforced |
+| `counterArgument` | 280 | Always enforced |
+| `assumptions[i]` | 200 | Per-entry |
+| `nextStepRationale` | 200 | Only enforced when `nextThoughtNeeded=true` |
+
+The caps are intentionally tight. They force one-tight-sentence-per-field discipline; padded prose returns an error rather than being silently accepted. If a critique genuinely needs more than 280 chars, split the thinking across two `criticalthinking` calls — that's the design intent.
+
+### `thoughtNumber` and `totalThoughts` are now optional after the first thought
+
+- Omit `thoughtNumber` to let the server auto-assign:
+  - **Trunk** thoughts: `len(history)+1`.
+  - **Branch** thoughts (when `branchFromThought` and `branchId` are set): position within the branch (1, 2, 3, …) — **not** a global ordinal.
+  - **Revisions** (when `isRevision` and `revisesThought` are set): next trunk slot.
+- Omit `totalThoughts` to inherit the most recent **trunk** thought's value. Branch thoughts are explicitly skipped during inheritance so a branch's auto-bumped `totalThoughts` cannot contaminate the trunk's running estimate.
+- The first trunk thought of a session must still send `totalThoughts` explicitly; omitting it returns `IsError: true`.
+- Sending values explicitly is still accepted and overrides — useful for unambiguous revisions or when a client treats `thoughtNumber` as a global ordinal.
+
+### Response no longer echoes `thoughtNumber` / `totalThoughts` / `nextThoughtNeeded`
+
+The caller already sent these — echoing them was pure redundancy. The response now contains only:
+
+```json
+{
+  "branches": [...],
+  "thoughtHistoryLength": N,
+  "sessionConfidence": 0.X,
+  "branchConfidences": { ... }
+}
+```
+
+Read the full per-thought state from the `thinking://current` resource if needed.
+
+### Binary, server name, and log line renamed to `rubber-ducky-mcp`
+
+For consistency with the Go module path. The Docker image build artifact and the MCP `Implementation.Name` field are now `rubber-ducky-mcp` (was `rubber-ducky-thinking`). Update `mcp.json` `command` fields and any shell-script references. Client-side server *aliases* (the key under `mcpServers`) are user-controlled and unaffected.
+
+## From `http-sequential-thinking` (Node predecessor)
+
+This Go server is the successor to `jacaudi/http-sequential-thinking`. The original differences:
+
+- **Tool renamed:** `sequentialthinking` → `criticalthinking`. Update `mcp.json` references.
+- **Required new fields:** every call must send `confidence`, `assumptions`, `critique`, `counterArgument`. Calls missing these fail with `IsError: true`.
+- **`nextStepRationale` required when `nextThoughtNeeded: true`.**
+- **Web UI removed.** Use [MCP Inspector](https://github.com/modelcontextprotocol/inspector) or `curl` for manual testing.
+- **CORS default tightened.** Set `ALLOWED_ORIGINS` explicitly to allow browser clients.
+
+The original `http-sequential-thinking` had no notion of confidence calibration, assumptions, critique, or counter-argument. That's the deliberate philosophical break: the original tool was infrastructure for sequential prompting; this one is infrastructure for critical sequential prompting.

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func runHTTP(addr string) {
 		}
 	}()
 
-	log.Printf("rubber-ducky-thinking %s listening on http://%s", version, listenAddr)
+	log.Printf("rubber-ducky-mcp %s listening on http://%s", version, listenAddr)
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("listen: %v", err)
 	}
@@ -131,7 +131,7 @@ func runHTTP(addr string) {
 // state). Stdio mode calls it once with a single global state.
 func newMCPServer(state *thinking.SequentialThinkingServer) *mcp.Server {
 	srv := mcp.NewServer(&mcp.Implementation{
-		Name:    "rubber-ducky-thinking",
+		Name:    "rubber-ducky-mcp",
 		Version: version,
 	}, nil)
 


### PR DESCRIPTION
## Summary

- **README rewrite, ≤120 lines (currently 97).** Sharp landing page: what it is, install, run, one-call example, client config, link to detail docs.
- **New \`docs/\` tree** with index + four detail pages (configuration, clients, development, migration). Migration log now reflects the length caps, optional \`thoughtNumber\`/\`totalThoughts\`, and response-echo trim that landed in #23.
- **Binary rename** \`rubber-ducky-thinking\` → \`rubber-ducky-mcp\` in the Dockerfile build artifact + ENTRYPOINT and in \`main.go\` (startup log + MCP \`Implementation.Name\`). Aligns the Docker image and protocol-advertised name with the Go-installed binary, which was already \`rubber-ducky-mcp\`. \`mcpServers.<alias>\` keys in client configs are user-controlled and unaffected.

## Why split the README?

The README had grown into a kitchen-sink reference: install, transports, configuration table, full migration log, and development notes all on one page, and it was already missing the recent length-cap and optional-field work. Adding all the new context inline would have pushed it past 200 lines. The split keeps the landing page skinnable while letting the detail pages grow without ceremony.

## What's in each new doc

- \`docs/README.md\` — index, one line per detail page
- \`docs/configuration.md\` — env vars, transports (stdio + HTTP), endpoints, session lifecycle, CORS/CSRF
- \`docs/clients.md\` — Claude Desktop, Codex CLI, VS Code, Cursor, Docker, generic HTTP recipes
- \`docs/development.md\` — build, test (\`-race\`), MCP Inspector, project layout, release workflow
- \`docs/migration.md\` — cumulative breaking-change log, most recent first

## Test plan

- [x] \`go test -race -count=1 ./...\` — green
- [x] \`go vet ./...\` — clean
- [x] \`gofmt -d .\` — clean
- [x] README confirmed ≤120 lines (97)
- [ ] Reviewer should confirm the binary rename doesn't surprise any internal automation that grepped for \`rubber-ducky-thinking\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)