### PR TITLE
Rename to critical-thinking; ship Claude Code plugin

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -35,7 +35,7 @@ runs:
       id: meta
       uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5
       with:
-        images: ghcr.io/${{ github.repository }}
+        images: ghcr.io/${{ github.repository_owner }}/critical-thinking
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -48,7 +48,7 @@ runs:
       uses: docker/bake-action@3acf805d94d93a86cce4ca44798a76464a75b88c # v6
       env:
         BUILD_DATE: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-        REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+        REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/critical-thinking
         SOURCE_COMMIT: ${{ github.sha }}
         VERSION: ${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
       with:

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -31,4 +31,4 @@ runs:
 
     - name: go build
       shell: bash
-      run: go build -trimpath -ldflags "-s -w" -o /tmp/rubber-ducky-thinking .
+      run: go build -trimpath -ldflags "-s -w" -o /tmp/critical-thinking ./cmd/critical-thinking

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,19 +18,19 @@ COPY . .
 RUN CGO_ENABLED=0 go build \
     -trimpath \
     -ldflags "-s -w -X main.version=${VERSION}" \
-    -o /out/rubber-ducky-mcp .
+    -o /out/critical-thinking ./cmd/critical-thinking
 
 # ---- final ----
 FROM gcr.io/distroless/static-debian12:nonroot AS release
 
-COPY --from=builder /out/rubber-ducky-mcp /rubber-ducky-mcp
+COPY --from=builder /out/critical-thinking /critical-thinking
 
-LABEL org.opencontainers.image.title="Rubber Ducky MCP"
-LABEL org.opencontainers.image.description="MCP server for critical, narrated, sequential thinking"
+LABEL org.opencontainers.image.title="Critical Thinking"
+LABEL org.opencontainers.image.description="MCP server for critical, narrated, sequential thinking — paired with a Claude Code skill"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILDTIME}"
 LABEL org.opencontainers.image.revision="${REVISION}"
-LABEL org.opencontainers.image.source="https://github.com/jacaudi/rubber-ducky-mcp"
+LABEL org.opencontainers.image.source="https://github.com/jacaudi/critical-thinking-plugin"
 
 ENV DOCKER=true
 EXPOSE 3000
@@ -39,5 +39,5 @@ EXPOSE 3000
 # /health from the network. No HEALTHCHECK directive in the image.
 
 USER nonroot:nonroot
-ENTRYPOINT ["/rubber-ducky-mcp"]
+ENTRYPOINT ["/critical-thinking"]
 CMD ["-http", ":3000"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Rubber Ducky MCP
+# Critical Thinking Plugin
 
-A Model Context Protocol server for **critical, narrated, sequential thinking**. A rubber duck you talk to while you think — one step at a time — with required confidence calibration and adversarial self-critique on every thought.
+A Model Context Protocol server for **critical, narrated, sequential thinking**. Think one step at a time, out loud — with required confidence calibration and adversarial self-critique on every thought.
 
 It fuses three disciplines:
 
 1. **Sequential thinking** — break problems into ordered, numbered steps; revise; branch.
-2. **Rubber-duck narration** — explain each thought out loud, in first-person, to an imagined listener.
+2. **Thinking out loud** — explain each thought in first-person, exploratory voice. Putting half-formed reasoning into words is itself the double-check on it.
 3. **Critical self-examination** — every thought is paired with confidence, assumptions, critique, and a counter-argument.
 
 The single tool is `criticalthinking`. Every call must include the four critical-thinking fields — there is no opt-out, by design.
@@ -13,24 +13,24 @@ The single tool is `criticalthinking`. Every call must include the four critical
 ## Install
 
 ```bash
-go install github.com/jacaudi/rubber-ducky-mcp@latest
+go install github.com/jacaudi/critical-thinking-plugin/cmd/critical-thinking@latest
 # or
-docker pull ghcr.io/jacaudi/rubber-ducky-mcp:latest
+docker pull ghcr.io/jacaudi/critical-thinking:latest
 ```
 
-The Go install lands the binary at `$GOPATH/bin/rubber-ducky-mcp`.
+The Go install lands the binary at `$GOPATH/bin/critical-thinking`.
 
 ## Run
 
 ```bash
 # stdio (default; for Claude Desktop, Codex CLI, VS Code, etc.)
-rubber-ducky-mcp
+critical-thinking
 
 # Streamable HTTP
-rubber-ducky-mcp -http :3000
+critical-thinking -http :3000
 
 # Docker (HTTP on :3000)
-docker run --rm -p 3000:3000 ghcr.io/jacaudi/rubber-ducky-mcp:latest
+docker run --rm -p 3000:3000 ghcr.io/jacaudi/critical-thinking:latest
 ```
 
 ## One-call example
@@ -55,7 +55,7 @@ Response (`structuredContent`):
 { "branches": [], "thoughtHistoryLength": 1, "sessionConfidence": 0.6 }
 ```
 
-The `text` content is a rendered transcript in rubber-duck voice. Subsequent calls can omit `thoughtNumber` (auto-assigned) and `totalThoughts` (inherited). Every critical-thinking field has a server-side length cap to enforce one-tight-sentence discipline. The full contract lives in the tool description itself.
+The `text` content is a rendered transcript in first-person, exploratory voice. Subsequent calls can omit `thoughtNumber` (auto-assigned) and `totalThoughts` (inherited). Every critical-thinking field has a server-side length cap to enforce one-tight-sentence discipline. The full contract lives in the tool description itself.
 
 ## Client setup
 
@@ -64,7 +64,7 @@ The `text` content is a rendered transcript in rubber-duck voice. Subsequent cal
 ```json
 {
   "mcpServers": {
-    "rubber-ducky": { "command": "rubber-ducky-mcp" }
+    "critical-thinking": { "command": "critical-thinking" }
   }
 }
 ```
@@ -74,7 +74,7 @@ Or HTTP:
 ```json
 {
   "mcpServers": {
-    "rubber-ducky": { "url": "http://localhost:3000/mcp" }
+    "critical-thinking": { "url": "http://localhost:3000/mcp" }
   }
 }
 ```
@@ -91,6 +91,10 @@ The server exposes `thinking://current` — a per-session JSON snapshot of the f
 - [docs/clients.md](docs/clients.md) — Claude Desktop, Codex CLI, VS Code, Cursor recipes
 - [docs/development.md](docs/development.md) — building, testing, debugging with MCP Inspector
 - [docs/migration.md](docs/migration.md) — breaking changes since `http-sequential-thinking`
+
+## Claude Code plugin
+
+The [`critical-thinking`](plugins/critical-thinking/) plugin teaches Claude *when* to reach for the `criticalthinking` tool — both as the primary thinking process (in place of silent extended thinking or v1 sequential-thinking) and as the post-hoc pressure-test after another thinking session. The MCP server is the *how* and *why*; the plugin is the *when*.
 
 ## License
 

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/jacaudi/rubber-ducky-mcp/internal/thinking"
+	"github.com/jacaudi/critical-thinking-plugin/internal/thinking"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -118,7 +118,7 @@ func runHTTP(addr string) {
 		}
 	}()
 
-	log.Printf("rubber-ducky-mcp %s listening on http://%s", version, listenAddr)
+	log.Printf("critical-thinking %s listening on http://%s", version, listenAddr)
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("listen: %v", err)
 	}
@@ -131,7 +131,7 @@ func runHTTP(addr string) {
 // state). Stdio mode calls it once with a single global state.
 func newMCPServer(state *thinking.SequentialThinkingServer) *mcp.Server {
 	srv := mcp.NewServer(&mcp.Implementation{
-		Name:    "rubber-ducky-mcp",
+		Name:    "critical-thinking",
 		Version: version,
 	}, nil)
 

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/jacaudi/rubber-ducky-mcp/internal/thinking"
+	"github.com/jacaudi/critical-thinking-plugin/internal/thinking"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -15,7 +15,7 @@ variable "SOURCE_COMMIT" {
 }
 
 variable "APP" {
-  default = "rubber-ducky-mcp"
+  default = "critical-thinking"
 }
 
 variable "VERSION" {
@@ -23,7 +23,7 @@ variable "VERSION" {
 }
 
 variable "SOURCE" {
-  default = "https://github.com/jacaudi/rubber-ducky-mcp"
+  default = "https://github.com/jacaudi/critical-thinking-plugin"
 }
 
 group "default" {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Reference material for `rubber-ducky-mcp`. The top-level [README](../README.md) is the landing page; everything below is detail.
+Reference material for `critical-thinking`. The top-level [README](../README.md) is the landing page; everything below is detail.
 
 | File | Covers |
 |---|---|

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,6 +1,6 @@
 # Client setup
 
-All snippets assume the binary `rubber-ducky-mcp` is on your `$PATH`. After `go install github.com/jacaudi/rubber-ducky-mcp@latest`, that's `$GOPATH/bin/rubber-ducky-mcp` — make sure `$GOPATH/bin` is on `$PATH`, or use the absolute path in the `command` field.
+All snippets assume the binary `critical-thinking` is on your `$PATH`. After `go install github.com/jacaudi/critical-thinking-plugin/cmd/critical-thinking@latest`, that's `$GOPATH/bin/critical-thinking` — make sure `$GOPATH/bin` is on `$PATH`, or use the absolute path in the `command` field.
 
 ## Claude Desktop
 
@@ -9,8 +9,8 @@ All snippets assume the binary `rubber-ducky-mcp` is on your `$PATH`. After `go 
 ```json
 {
   "mcpServers": {
-    "rubber-ducky": {
-      "command": "rubber-ducky-mcp"
+    "critical-thinking": {
+      "command": "critical-thinking"
     }
   }
 }
@@ -25,8 +25,8 @@ Restart Claude Desktop after editing.
 ```json
 {
   "mcpServers": {
-    "rubber-ducky": {
-      "command": "rubber-ducky-mcp"
+    "critical-thinking": {
+      "command": "critical-thinking"
     }
   }
 }
@@ -39,8 +39,8 @@ Most VS Code MCP-aware extensions use the same `mcp.json` shape:
 ```json
 {
   "mcpServers": {
-    "rubber-ducky": {
-      "command": "rubber-ducky-mcp"
+    "critical-thinking": {
+      "command": "critical-thinking"
     }
   }
 }
@@ -53,27 +53,27 @@ Most VS Code MCP-aware extensions use the same `mcp.json` shape:
 ```json
 {
   "mcpServers": {
-    "rubber-ducky": {
+    "critical-thinking": {
       "url": "http://localhost:3000/mcp"
     }
   }
 }
 ```
 
-(Cursor currently prefers HTTP transport.) Run the server separately with `rubber-ducky-mcp -http :3000`.
+(Cursor currently prefers HTTP transport.) Run the server separately with `critical-thinking -http :3000`.
 
 ## Generic HTTP (any client)
 
 Run the server in HTTP mode and point your client at `/mcp`:
 
 ```bash
-rubber-ducky-mcp -http :3000
+critical-thinking -http :3000
 ```
 
 ```json
 {
   "mcpServers": {
-    "rubber-ducky": {
+    "critical-thinking": {
       "url": "http://localhost:3000/mcp"
     }
   }
@@ -85,7 +85,7 @@ For browser-based clients, set `ALLOWED_ORIGINS` to permit your origin — see [
 ## Docker
 
 ```bash
-docker run -d --name rubber-ducky -p 3000:3000 ghcr.io/jacaudi/rubber-ducky-mcp:latest
+docker run -d --name critical-thinking -p 3000:3000 ghcr.io/jacaudi/critical-thinking:latest
 ```
 
 Then use the HTTP client config above. The image binds to `0.0.0.0` automatically (via `DOCKER=true`); pair it with appropriate firewall rules in production.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,7 @@
 ### Stdio (default)
 
 ```bash
-rubber-ducky-mcp
+critical-thinking
 ```
 
 One process serves one session. There is no cross-stream isolation concern because there is no second stream — the process IS the session. Use this for direct integration with MCP hosts (Claude Desktop, Codex CLI, VS Code).
@@ -21,7 +21,7 @@ One process serves one session. There is no cross-stream isolation concern becau
 ### Streamable HTTP
 
 ```bash
-rubber-ducky-mcp -http :3000
+critical-thinking -http :3000
 ```
 
 The HTTP server binds to `127.0.0.1` by default (or `0.0.0.0` when `DOCKER=true`). Each session gets its own `*mcp.Server` with its own `SequentialThinkingServer`, constructed inside a factory closure — there is no map keyed by session ID anywhere, by design. The closure scope is the cross-session isolation invariant.

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,7 +7,7 @@ Go 1.26+. No other build dependencies (the MCP SDK is a Go module).
 ## Build
 
 ```bash
-go build -ldflags "-X main.version=$(git describe --tags --always)" -o rubber-ducky-mcp .
+go build -ldflags "-X main.version=$(git describe --tags --always)" -o critical-thinking ./cmd/critical-thinking
 ```
 
 The `-X main.version=...` flag stamps the build with a version string surfaced via `/health` and the MCP `Implementation.Version`.
@@ -28,10 +28,10 @@ The fastest way to manually exercise the tool is the official [MCP Inspector](ht
 
 ```bash
 # stdio
-npx @modelcontextprotocol/inspector rubber-ducky-mcp
+npx @modelcontextprotocol/inspector critical-thinking
 
 # HTTP
-rubber-ducky-mcp -http :3000 &
+critical-thinking -http :3000 &
 npx @modelcontextprotocol/inspector --uri http://localhost:3000/mcp
 ```
 
@@ -41,22 +41,24 @@ The inspector lets you call `criticalthinking` interactively, watch the rendered
 
 ```
 .
-├── main.go                       # MCP transport adapter (stdio + HTTP)
-├── main_test.go                  # cross-session isolation integration test
+├── cmd/critical-thinking/
+│   ├── main.go                   # MCP transport adapter (stdio + HTTP)
+│   └── main_test.go              # cross-session isolation integration test
 ├── internal/thinking/
 │   ├── description.go            # tool description (the prompt-engineering contract)
 │   ├── schema.go                 # ThoughtData / ThoughtResponse + Validate()
 │   ├── server.go                 # SequentialThinkingServer state machine
 │   └── *_test.go                 # unit tests
+├── plugins/critical-thinking/    # Claude Code plugin (skill + manifest)
 ├── Dockerfile                    # multi-stage, distroless final
 └── docker-bake.hcl               # buildx bake config
 ```
 
-The `internal/thinking` package has zero dependency on the MCP SDK — `main.go` is the only adapter. That keeps the state machine fully unit-testable.
+The `internal/thinking` package has zero dependency on the MCP SDK — `cmd/critical-thinking/main.go` is the only adapter. That keeps the state machine fully unit-testable.
 
 ## Release workflow
 
-CI runs on push and PR via GitHub Actions: `vet`, `gofmt`, `go test -race -count=1 ./...`, and a Docker build. Releases are tag-driven; tagging `vX.Y.Z` triggers the release workflow which builds and pushes the multi-arch Docker image to `ghcr.io/jacaudi/rubber-ducky-mcp:vX.Y.Z` and updates `:latest`.
+CI runs on push and PR via GitHub Actions: `vet`, `gofmt`, `go test -race -count=1 ./...`, and a Docker build. Releases are tag-driven; tagging `vX.Y.Z` triggers the release workflow which builds and pushes the multi-arch Docker image to `ghcr.io/jacaudi/critical-thinking:vX.Y.Z` and updates `:latest`.
 
 ## Treating the description as a protocol
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,6 +1,23 @@
 # Migration
 
-Cumulative breaking-change log for `rubber-ducky-mcp`. Most recent changes first.
+Cumulative breaking-change log for `critical-thinking`. Most recent changes first.
+
+## Project rename: `rubber-ducky-mcp` → `critical-thinking`
+
+The whole project was renamed to align with the discipline it teaches. Specifics:
+
+- **GitHub repo** moved to `jacaudi/critical-thinking-plugin` (the `-plugin` suffix only appears in the repo URL and top-level README title).
+- **Go module path** is now `github.com/jacaudi/critical-thinking-plugin` (follows the repo URL). Update import paths if you depend on `internal/thinking` from outside this repo.
+- **Entry point moved to `./cmd/critical-thinking/`.** `go install` is now `go install github.com/jacaudi/critical-thinking-plugin/cmd/critical-thinking@latest`. The binary still lands at `$GOPATH/bin/critical-thinking`. Build commands updated everywhere (Dockerfile, CI action, dev docs).
+- **Binary name** is now `critical-thinking` (was `rubber-ducky-mcp`). Update `mcp.json` `command` fields and any shell scripts.
+- **Docker image** is now `ghcr.io/jacaudi/critical-thinking:<tag>` (was `ghcr.io/jacaudi/rubber-ducky-mcp:<tag>`). The previous image tags remain accessible at the old name until removed; new releases publish only to the new name.
+- **MCP `Implementation.Name`** is now `critical-thinking` (was `rubber-ducky-mcp`). Affects what hosts display in their MCP server lists.
+- **Server log line** prefix updated to `critical-thinking`.
+- **Client-side server aliases** (the key under `mcpServers` in `mcp.json`) are user-controlled and unaffected. Suggested key in docs is now `"critical-thinking"`.
+
+## Tool description rewritten — "Thinking out loud" replaces the rubber-duck framing
+
+The verbatim description registered on the `criticalthinking` tool was rewritten. Discipline #2 changed from "Rubber-duck narration" to "Thinking out loud." The mechanism is unchanged (first-person, exploratory voice; hedges and self-corrections welcome) but the framing is now: putting half-formed reasoning into words is itself the double-check on it. No field semantics changed; no caps changed; no required fields added or removed. Per the protocol-level treatment of `description.go`, this is a behavior-affecting change for client agents that read the tool description and adjust their voice.
 
 ## From `0.6.x` (post-rewrite, prior to length-cap and optional-field work)
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jacaudi/rubber-ducky-mcp
+module github.com/jacaudi/critical-thinking-plugin
 
 go 1.26
 

--- a/internal/thinking/description.go
+++ b/internal/thinking/description.go
@@ -2,25 +2,27 @@ package thinking
 
 // ToolDescription is the verbatim description string registered on the
 // criticalthinking MCP tool. Every agent calling the tool reads this — it is
-// the prompt-engineering contract for rubber-duck narration + critical self-
+// the prompt-engineering contract for thinking out loud + critical self-
 // examination on top of sequential thinking.
 //
 // Treat changes here as protocol changes: bump the package version and
 // document in the README migration notes.
-const ToolDescription = `A tool for *critical*, *narrated*, *sequential* problem-solving — a rubber duck
-you talk to while you think one step at a time. This tool fuses three disciplines:
+const ToolDescription = `A tool for *critical*, *narrated*, *sequential* problem-solving. Think one
+step at a time, out loud, and interrogate each thought as it lands. This tool
+fuses three disciplines:
 
   1. Sequential thinking — break the problem into ordered, numbered steps. Each
      thought builds on the previous ones; you can revise earlier steps and branch
      into alternatives when the path forks.
-  2. Rubber-duck narration — explain each thought out loud, in first-person,
-     to an imagined listener. The act of explaining surfaces the assumptions
-     you didn't know you were making.
+  2. Thinking out loud — explain each thought in first-person, exploratory voice.
+     The act of putting half-formed reasoning into words is itself a check on it:
+     vague thought stays vague until you have to say it. Externalizing the
+     thinking is what surfaces the assumptions you didn't know you were making.
   3. Critical self-examination — every thought is paired with confidence,
      assumptions, critique, and a counter-argument. You produce the thought,
      then you interrogate it, in the same call.
 
-Sequential thinking is the *spine*. Rubber-ducking is the *voice*. Critical
+Sequential thinking is the *spine*. Thinking out loud is the *voice*. Critical
 self-examination is the *check*. Skipping any one of them is a misuse.
 
 How a session unfolds:
@@ -38,7 +40,7 @@ How a session unfolds:
   - Adjust totalThoughts as understanding evolves. Set nextThoughtNeeded=false
     only when the work is genuinely done.
 
-For each call, you write ONE thought as if explaining it to a patient listener.
+For each call, you write ONE thought as if explaining it out loud to yourself.
 Then, in the same call, you provide:
 
   - confidence (0.0–1.0): How sure are you, *honestly*? 0.5 means a coin flip.
@@ -59,10 +61,10 @@ Then, in the same call, you provide:
 
 Voice and register for the thought field:
   - First-person, narrative, exploratory. "I think... but wait... actually..."
-  - Include hedges, false starts, and self-corrections — that's the rubber-duck
+  - Include hedges, false starts, and self-corrections — that's the exploratory
     register, not noise.
-  - Address an imagined listener. The discipline of explaining out loud is what
-    surfaces hidden assumptions.
+  - The aim is to externalize the thinking, not to perform polished prose.
+    Putting thought into words is the double-check; vague thought stays vague.
   - This is NOT polished prose. Polished prose hides uncertainty. Be messy and
     honest.
 
@@ -77,7 +79,7 @@ Anti-patterns to avoid:
     next thought, not to satisfy the schema.
 
 What you get back:
-  - A narrated transcript of this thought (rendered in rubber-duck voice).
+  - A narrated transcript of this thought (first-person, exploratory voice).
   - Running session confidence (mean of trunk thoughts).
   - Per-branch confidence (if any branches exist).
   - The full state needed to plan the next call.

--- a/internal/thinking/server.go
+++ b/internal/thinking/server.go
@@ -69,7 +69,7 @@ func (s *SequentialThinkingServer) LastAccessed() time.Time {
 // adapts it into a *mcp.CallToolResult — keeping mcp imports out of this
 // package preserves its testability.
 type ToolResult struct {
-	Text           string // the rubber-duck transcript (or error JSON when IsError)
+	Text           string // the thinking-out-loud transcript (or error JSON when IsError)
 	StructuredJSON string // JSON-encoded ThoughtResponse, "" when IsError
 	IsError        bool
 }
@@ -152,7 +152,7 @@ func (s *SequentialThinkingServer) ProcessThought(td ThoughtData) (ToolResult, e
 	}, nil
 }
 
-// renderTranscriptLocked builds the rubber-duck transcript text for one thought.
+// renderTranscriptLocked builds the narrated transcript text for one thought.
 // Caller must hold s.mu.
 func (s *SequentialThinkingServer) renderTranscriptLocked(td ThoughtData, sessionConf float64) string {
 	var b strings.Builder

--- a/plugins/critical-thinking/.claude-plugin/plugin.json
+++ b/plugins/critical-thinking/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "critical-thinking",
+  "description": "When-to-use discipline for the critical-thinking MCP server's criticalthinking tool — the v2 substitute for sequential-thinking",
+  "version": "0.1.0",
+  "author": {
+    "name": "jacaudi",
+    "url": "https://github.com/jacaudi"
+  },
+  "homepage": "https://github.com/jacaudi/critical-thinking-plugin/tree/main/plugins/critical-thinking",
+  "repository": "https://github.com/jacaudi/critical-thinking-plugin",
+  "license": "MIT"
+}

--- a/plugins/critical-thinking/README.md
+++ b/plugins/critical-thinking/README.md
@@ -1,0 +1,60 @@
+# critical-thinking
+
+A Claude Code plugin that teaches Claude *when* to invoke the `criticalthinking` tool exposed by the [critical-thinking](https://github.com/jacaudi/critical-thinking-plugin) MCP server.
+
+The MCP server documents *how* and *why*. This plugin owns *when*.
+
+## What it does
+
+Ships one skill, `critical-thinking`, that fires as the default discipline for any non-trivial reasoning — in two modes:
+
+1. **Mode 1 — primary thinking.** When you would otherwise reach for silent extended thinking or `mcp__sequential-thinking__sequentialthinking`, route the work through `criticalthinking` instead.
+2. **Mode 2 — post-hoc pressure-test.** When the thinking already happened in another channel (silent extended thinking, native chain-of-reasoning, a v1 sequential-thinking session), externalize the review through `criticalthinking` before acting.
+
+Mode 1 is preferred when you control the entry point; Mode 2 is the fallback when the thinking has already happened.
+
+## v2 of sequential-thinking
+
+`criticalthinking` is a strict superset of `mcp__sequential-thinking__sequentialthinking`'s schema. Every v1 field is present with the same semantics. Added on top: required `confidence`, `assumptions`, `critique`, `counterArgument`, and `nextStepRationale` fields, plus per-call and per-branch confidence tracking. The discipline isn't optional — it's enforced by the schema.
+
+When this plugin is installed, prefer `criticalthinking` over the v1 tool for every use case the v1 tool covers.
+
+## Dependency
+
+This plugin requires the `critical-thinking` MCP server to be installed and configured separately. The skill calls the server's `criticalthinking` tool — without the server, the skill has nothing to invoke.
+
+- Server source: https://github.com/jacaudi/critical-thinking-plugin
+- Server configuration: see `docs/configuration.md` in the server repo for stdio and HTTP transport setup.
+
+## Install
+
+This plugin is distributed via a Claude Code plugin marketplace. The marketplace that lists it is hosted separately; consult that marketplace's documentation for the exact `/plugin marketplace add` and `/plugin install` commands.
+
+Once installed, the skill is available to Claude immediately — no further configuration.
+
+## Usage
+
+Two invocation modes, both supported out of the box:
+
+**Auto-invocation.** Claude triggers the skill on its own whenever non-trivial reasoning is involved — driven by the skill's description. No user action required.
+
+**Manual invocation.** Type:
+
+```
+/critical-thinking:critical-thinking
+```
+
+…or use natural language: "think this through," "critique this," "pressure-test that conclusion," "branch on this," "revise that earlier thought." Claude invokes the skill on whatever subject you named.
+
+## Scope
+
+This plugin contains exactly one skill. No hooks, no slash commands beyond the auto-generated plugin-namespaced one, no agents.
+
+## See also
+
+- Top-level project: [Critical Thinking Plugin](../../README.md)
+- MCP server source: https://github.com/jacaudi/critical-thinking-plugin
+
+## License
+
+See the parent repository for license terms.

--- a/plugins/critical-thinking/skills/critical-thinking/SKILL.md
+++ b/plugins/critical-thinking/skills/critical-thinking/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: critical-thinking
+description: |
+  Use as the default discipline for any non-trivial reasoning that warrants
+  externalized step-by-step thought — either as the primary thinking process
+  or as the post-hoc pressure-test after another thinking session. Triggers:
+  complex problem breakdown, planning with revision, multi-step solutions,
+  design or architecture decisions, debugging conclusions about to be acted
+  on, forced-choice engineering decisions (even when the user-facing answer
+  is one line), any moment where being wrong is expensive. Use even when the
+  user says "don't overthink it," "just give me the answer," or imposes a
+  tight deadline — those are pressure signals, not skip signals. Skip only
+  for direct lookups, file reads, mechanical edits, and pure syntax
+  questions. Also fires on user prompts like "think this through,"
+  "critique this," "pressure-test that," "branch on this," "revise that
+  thought," or /critical-thinking:critical-thinking.
+disable-model-invocation: false
+user-invocable: true
+---
+
+# Critical Thinking
+
+`criticalthinking` is **sequential thinking, v2** — `mcp__sequential-thinking__sequentialthinking` with the discipline layer enforced by the schema. Same shape: numbered thoughts, `totalThoughts`, `isRevision` / `revisesThought`, `branchFromThought` / `branchId`, `needsMoreThoughts`. Added on top: required `confidence`, `assumptions`, `critique`, `counterArgument`, and `nextStepRationale` fields, plus per-call and per-branch confidence tracking. When `criticalthinking` is available, prefer it for every use case the v1 tool covers.
+
+This skill governs **when** to use it. The tool itself documents *how* (fields, branching mechanics, voice register, stopping criteria) and *why* (sequential thinking + thinking out loud + critical self-examination). Read the tool description when you call it; this skill only decides when calling it is the right move.
+
+## Two modes — both default-on
+
+**Mode 1 — as the thinking itself.** When you would otherwise reach for silent extended thinking or `mcp__sequential-thinking__sequentialthinking`, use `criticalthinking` instead. The thinking *is* externalized — putting it into words is the double-check.
+
+**Mode 2 — as the pressure-test after the fact.** When the thinking already happened in another channel (silent extended thinking, native chain-of-reasoning, or a v1 sequential-thinking session), run `criticalthinking` to externalize the review before acting.
+
+**Prefer Mode 1 when you control the entry point.** Mode 2 has a rationalization risk: the conclusion is already formed and the critique can drift into post-hoc justification rather than honest attack. Mode 1 attacks the thought in the same call that produced it.
+
+## When to use
+
+- Breaking a complex problem into ordered steps.
+- Planning or designing where the path may need revision.
+- Multi-step solutions that need to maintain context across calls.
+- Design, architecture, or debugging conclusions about to be acted on.
+- Forced-choice decisions on real engineering questions (pick A/B/C, recommend an algorithm, root-cause a bug) — even when the user-facing *answer* is one line, the *decision* warrants the discipline.
+- After silent extended thinking or a v1 sequential-thinking session — before acting on the conclusion.
+- Any case where being wrong is expensive.
+
+## Sizing the session
+
+Always pick a size before the first call. Match thought count to problem complexity:
+
+| Size   | Thoughts | Use for |
+|--------|----------|---------|
+| Small  | 1–3      | Single decision, narrow scope. Recommending an algorithm, picking between 2–3 libs, sanity-checking a config, root-causing a bug with one obvious suspect. |
+| Medium | 3–5      | Multi-factor decision with some unknowns. Designing an API, root-causing with multiple suspects, planning a focused refactor. |
+| Large  | 5–9+     | Open-ended, multiple paths to compare, cross-system reasoning. Architecture decisions, comparing 3+ designs, debugging a tricky cross-component bug. |
+
+Set `totalThoughts` to the upper end of the chosen range up front. The schema lets you revise upward via `needsMoreThoughts` if a thought reveals unexpected depth, or stop early via `nextThoughtNeeded: false` if you converge sooner. **Mode 2 (post-hoc pressure-test) defaults to small (1–3)** — it's a check, not a re-derivation.
+
+## When to skip
+
+- Direct lookups (a fact you can recall without weighing alternatives).
+- File reads, listing files, mechanical edits with no judgment call.
+- Pure syntax questions ("what's the regex for X").
+- Acknowledgements, status updates, formatting fixes.
+
+**Length of the expected answer is NOT a skip criterion.** A one-line recommendation on a non-trivial engineering decision still warrants one `criticalthinking` call (small, 1–3 thoughts).
+
+## Pressure rationalizations — do not be talked out of the discipline
+
+The user will sometimes apply pressure that *sounds* like permission to skip. It isn't. If any of these thoughts surface, that is the signal to use the tool — not the signal to skip it.
+
+| Pressure / rationalization | Reality |
+|---|---|
+| "Don't overthink it." | One small (1–3 thought) `criticalthinking` session IS being decisive — it forces a sharp answer with the critique built in. Skipping the tool is not less thinking; it is hidden thinking. |
+| "Tight deadline / 5 minutes." | A small session is fast. Being wrong under deadline is the slow path — you'll redo the work. Discipline is the speed move, not the slow one. |
+| "It's low stakes." | If the user asked, the stakes aren't yours to declare. Production APIs, payments, architecture decisions — not low-stakes regardless of how the question was framed. |
+| "I know this domain — the answer is well-established." | Confident recall is exactly when you're most likely to skip the assumption you're carrying. The discipline IS the check on that. |
+| "User wants a one-line answer." | They want a sharp answer. The tool produces one — the critique is internal to your reasoning; the user-facing reply can still be one line. |
+| "It's a single forced-choice between known options." | Forced choice on a real decision is exactly the small-session use case. The user is asking you to commit; commit through the discipline. |
+
+## Relationship to other tools
+
+- **`mcp__sequential-thinking__sequentialthinking` (v1 tool)** — superseded by `criticalthinking` for the same use cases. Same shape, weaker contract. Do not silently fall back to v1 when this skill is loaded — that defeats the substitution.
+- **Native extended thinking** — internal-only, no externalized review. After any non-trivial native thinking session, route through `criticalthinking` (Mode 2, small) before acting on the conclusion.
+
+## Dependency
+
+Requires the `critical-thinking` MCP server. `criticalthinking` is "unavailable" when it is not present in the available tools list, or when calls return a connection/transport error (not a schema-validation error — those are caller bugs to fix, not unavailability). On unavailability, tell the user the server is required and link https://github.com/jacaudi/critical-thinking-plugin. Do not silently fall back to `mcp__sequential-thinking__sequentialthinking` or to plain prose — both defeat the substitution.


### PR DESCRIPTION
## Summary
- Project renamed from `rubber-ducky-mcp` to `critical-thinking` (binary, MCP `Implementation.Name`, Docker image, log line, mcp.json suggested key). Repo URL gets the `-plugin` suffix; Go module path follows the repo. Entry point moved to `cmd/critical-thinking/` so `go install …/cmd/critical-thinking@latest` produces the right binary name.
- Tool description in `internal/thinking/description.go` rewritten — discipline #2 changed from "Rubber-duck narration" to "Thinking out loud." Mechanism preserved (first-person, exploratory, hedge-friendly voice); framing now emphasizes that putting half-formed reasoning into words is itself the double-check on it.
- New Claude Code plugin at `plugins/critical-thinking/` ships a single skill (`critical-thinking`) that teaches Claude *when* to invoke the `criticalthinking` tool. Two modes (primary thinking vs. post-hoc pressure-test), session sizing (small 1–3 / medium 3–5 / large 5–9+), and a pressure-rationalizations table built via RED-GREEN-REFACTOR with subagent baseline testing.
- `docs/migration.md` documents both the rename and the description rewrite at the top of the log; the predecessor `rubber-ducky-thinking → rubber-ducky-mcp` historical entry is preserved.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -race ./...` passes
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] CI green on branch push (run 25542655576)
- [x] Final grep: only intentional `rubber*` mentions remain (current + historical migration entries)
- [x] Independent code review by fresh subagent — two blocking issues caught (`go install` binary-name mismatch; OCI `image.source` URL clobbered) and fixed
- [ ] Verify Docker image builds + publishes to `ghcr.io/jacaudi/critical-thinking` on next release tag
- [ ] Update any external references (docs, blog posts, marketplace listings) that linked to the old name / image

🤖 Generated with [Claude Code](https://claude.com/claude-code)