### PR TITLE
Plugin install plumbing: marketplace, mcp.json, release pipeline, install hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "critical-thinking-plugin",
+  "description": "MCP server for critical, narrated, sequential thinking — paired with a Claude Code skill that teaches when to invoke it.",
+  "owner": {
+    "name": "jacaudi",
+    "url": "https://github.com/jacaudi"
+  },
+  "plugins": [
+    {
+      "name": "critical-thinking",
+      "version": "0.1.0",
+      "source": "./plugins/critical-thinking",
+      "description": "When-to-use discipline for the criticalthinking tool — the v2 substitute for sequential-thinking."
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+---
+# Release pipeline: semantic-release analyses conventional commits on main,
+# decides whether a new version is warranted, and (on release) invokes
+# goreleaser to cross-compile the critical-thinking binary and attach the
+# archives to the GitHub Release.
+name: Release
+
+"on":
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# One release at a time; queue subsequent runs.
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    uses: jacaudi/github-actions/.github/workflows/component-semantic-release.yml@v0.20.3
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    with:
+      use-github-app: true
+      go: true
+      goreleaser: true
+      extra-plugins: '@semantic-release/changelog @semantic-release/git @semantic-release/exec'
+    secrets:
+      app-id: ${{ secrets.BOT_APP_ID }}
+      app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ docs/codebase-review.md
 docs/plans/2025-11-21-go-multiuser-sequential-thinking.md
 docs/plans/2026-04-25-rubber-ducky-mcp-design.md
 docs/plans/2026-04-25-rubber-ducky-mcp-implementation.md
+docs/plans/2026-05-05-rubber-duck-skill-design.md
+docs/plans/2026-05-05-rubber-duck-skill-implementation.md
+plugins/critical-thinking/bin/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+project_name: critical-thinking
+builds:
+  - dir: ./cmd/critical-thinking
+    main: .
+    binary: critical-thinking
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+archives:
+  - name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+checksum:
+  name_template: "checksums.txt"
+release:
+  # semantic-release owns the GitHub Release; goreleaser only produces artifacts.
+  disable: true
+changelog:
+  # semantic-release owns the changelog.
+  disable: true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,52 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "releaseRules": [
+        { "breaking": true, "release": "minor" },
+        { "type": "refactor", "release": "minor" },
+        { "type": "chore", "scope": "deps", "release": "patch" }
+      ]
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "presetConfig": {
+        "types": [
+          { "type": "feat",     "section": "Features" },
+          { "type": "fix",      "section": "Bug Fixes" },
+          { "type": "perf",     "section": "Performance Improvements" },
+          { "type": "revert",   "section": "Reverts" },
+          { "type": "refactor", "section": "Refactors" },
+          { "type": "docs",     "section": "Documentation" },
+          { "type": "build",    "section": "Build System" },
+          { "type": "ci",       "section": "Continuous Integration" },
+          { "type": "chore",    "scope": "deps", "section": "Dependencies" },
+          { "type": "chore",    "section": "Chores" },
+          { "type": "test",     "section": "Tests" },
+          { "type": "style",    "section": "Styles", "hidden": true }
+        ]
+      },
+      "writerOpts": {
+        "headerPartial": "## {{#if @root.linkCompare~}}[{{version}}]({{@root.host}}/{{@root.owner}}/{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}){{~else}}{{~version}}{{~/if}} ({{date}})"
+      }
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md",
+      "changelogTitle": "# Changelog"
+    }],
+    ["@semantic-release/exec", {
+      "publishCmd": "goreleaser release --clean --skip=validate"
+    }],
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md"],
+      "message": "release: v${nextRelease.version} [skip ci]"
+    }],
+    ["@semantic-release/github", {
+      "assets": [
+        {"path": "dist/*.tar.gz"},
+        {"path": "dist/*.zip"},
+        {"path": "dist/checksums.txt"}
+      ]
+    }]
+  ]
+}

--- a/plugins/critical-thinking/.mcp.json
+++ b/plugins/critical-thinking/.mcp.json
@@ -1,0 +1,7 @@
+{
+  "mcpServers": {
+    "critical-thinking": {
+      "command": "critical-thinking"
+    }
+  }
+}

--- a/plugins/critical-thinking/.mcp.json
+++ b/plugins/critical-thinking/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "critical-thinking": {
-      "command": "critical-thinking"
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/critical-thinking"
     }
   }
 }

--- a/plugins/critical-thinking/hooks/hooks.json
+++ b/plugins/critical-thinking/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "critical-thinking plugin: ensure the MCP server binary is installed at session start",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/install-binary.sh\"",
+            "async": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/critical-thinking/hooks/install-binary.sh
+++ b/plugins/critical-thinking/hooks/install-binary.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Download the critical-thinking MCP server binary from the latest GitHub
+# Release for the current platform and stash it under ${CLAUDE_PLUGIN_ROOT}/bin/
+# so the plugin's .mcp.json can launch it without a Go toolchain on the host.
+#
+# Idempotent: re-runs are no-ops once the binary is in place. Re-download by
+# deleting ${CLAUDE_PLUGIN_ROOT}/bin/critical-thinking.
+#
+# Windows note: requires Git Bash, WSL, or another POSIX shell environment.
+
+set -euo pipefail
+
+REPO="jacaudi/critical-thinking-plugin"
+PROJECT="critical-thinking"
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]:-$0}" 2>/dev/null || echo "${BASH_SOURCE[0]:-$0}")")"/.. && pwd)}"
+BIN_DIR="${PLUGIN_ROOT}/bin"
+BIN_PATH="${BIN_DIR}/${PROJECT}"
+
+if [[ -x "${BIN_PATH}" ]]; then
+  exit 0
+fi
+
+case "$(uname -s)" in
+  Linux*)               OS=linux ;;
+  Darwin*)              OS=darwin ;;
+  MINGW*|MSYS*|CYGWIN*) OS=windows ;;
+  *)
+    echo "critical-thinking: unsupported OS: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64)  ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *)
+    echo "critical-thinking: unsupported arch: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+# Resolve latest release tag (no jq dependency).
+LATEST_TAG=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+  | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
+
+if [[ -z "${LATEST_TAG}" ]]; then
+  echo "critical-thinking: could not resolve latest release tag from https://api.github.com/repos/${REPO}/releases/latest" >&2
+  echo "critical-thinking: ensure a release exists, or install the binary manually and put it on PATH." >&2
+  exit 1
+fi
+
+VERSION="${LATEST_TAG#v}"
+
+EXT="tar.gz"
+[[ "${OS}" == "windows" ]] && EXT="zip"
+
+URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}/${PROJECT}_${VERSION}_${OS}_${ARCH}.${EXT}"
+
+echo "critical-thinking: downloading ${URL}" >&2
+
+mkdir -p "${BIN_DIR}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+if [[ "${EXT}" == "tar.gz" ]]; then
+  curl -fsSL "${URL}" | tar -xzC "${TMPDIR}"
+else
+  curl -fsSL -o "${TMPDIR}/release.zip" "${URL}"
+  unzip -q "${TMPDIR}/release.zip" -d "${TMPDIR}"
+fi
+
+# Goreleaser archives place the binary at the archive root.
+SRC="${TMPDIR}/${PROJECT}"
+[[ "${OS}" == "windows" ]] && SRC="${TMPDIR}/${PROJECT}.exe"
+
+if [[ ! -f "${SRC}" ]]; then
+  echo "critical-thinking: archive did not contain ${SRC}" >&2
+  exit 1
+fi
+
+mv "${SRC}" "${BIN_PATH}"
+chmod +x "${BIN_PATH}"
+
+echo "critical-thinking: installed ${BIN_PATH} (release ${LATEST_TAG})" >&2


### PR DESCRIPTION
## Summary
End-to-end plumbing so `claude plugin install critical-thinking@critical-thinking-plugin` works without manual binary install.

- **Marketplace manifest** at `.claude-plugin/marketplace.json` — repo can be added via `claude plugin marketplace add jacaudi/critical-thinking-plugin`.
- **Plugin `.mcp.json`** at `plugins/critical-thinking/.mcp.json` — registers the `critical-thinking` MCP server, pointing at the plugin-local binary path.
- **Release pipeline** (`.releaserc.json` + `.goreleaser.yaml` + `.github/workflows/release.yml`) using `jacaudi/github-actions/component-semantic-release@v0.20.3` with `goreleaser: true` — cross-compiles the binary for linux/darwin/windows × amd64/arm64 and attaches archives to GitHub Releases.
- **SessionStart install hook** (`plugins/critical-thinking/hooks/`) — on first session after install, detects OS/arch, fetches the matching archive from the latest GitHub Release, and drops the binary at `${CLAUDE_PLUGIN_ROOT}/bin/critical-thinking`. Idempotent.

## Install flow (after merge + first release)
```
claude plugin marketplace add jacaudi/critical-thinking-plugin
claude plugin install critical-thinking@critical-thinking-plugin
# → SessionStart hook downloads the right binary on first session
# → MCP server starts via the plugin-local path
# → critical-thinking skill is auto-invoked per its triggers
```

## Test plan
- [x] `claude plugin validate <repo>` and plugin manifest both pass
- [x] `bash -n install-binary.sh` syntax check passes
- [ ] CI green
- [ ] After merge: first semantic-release run produces v0.1.0 tag, goreleaser uploads cross-platform archives to the release
- [ ] After release: `claude plugin install critical-thinking@critical-thinking-plugin` end-to-end works on darwin/arm64 (test this first since user is on darwin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)