### PR TITLE
refactor!: rename module path to critical-thinking-mcp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
   # Build and push the multi-arch container image with the full set of
   # version tags. Image name decouples from the repo name (which carries the
-  # `-plugin` suffix) so users pull `ghcr.io/jacaudi/critical-thinking`.
+  # `-mcp` suffix) so users pull `ghcr.io/jacaudi/critical-thinking`.
   container-image:
     needs: [release, version-parts]
     if: needs.release.outputs.new-release-published == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.description="MCP server for critical, narrated, s
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILDTIME}"
 LABEL org.opencontainers.image.revision="${REVISION}"
-LABEL org.opencontainers.image.source="https://github.com/jacaudi/critical-thinking-plugin"
+LABEL org.opencontainers.image.source="https://github.com/jacaudi/critical-thinking-mcp"
 
 ENV DOCKER=true
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Critical Thinking Plugin
+# Critical Thinking MCP
 
 A Model Context Protocol server for **critical, narrated, sequential thinking**. Think one step at a time, out loud — with required confidence calibration and adversarial self-critique on every thought.
 
@@ -13,7 +13,7 @@ The single tool is `criticalthinking`. Every call must include the four critical
 ## Install
 
 ```bash
-go install github.com/jacaudi/critical-thinking-plugin/cmd/critical-thinking@latest
+go install github.com/jacaudi/critical-thinking-mcp/cmd/critical-thinking@latest
 # or
 docker pull ghcr.io/jacaudi/critical-thinking:v1.2.0
 ```

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/jacaudi/critical-thinking-plugin/internal/thinking"
+	"github.com/jacaudi/critical-thinking-mcp/internal/thinking"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/jacaudi/critical-thinking-plugin/internal/thinking"
+	"github.com/jacaudi/critical-thinking-mcp/internal/thinking"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,6 +1,6 @@
 # Client setup
 
-All snippets assume the binary `critical-thinking` is on your `$PATH`. After `go install github.com/jacaudi/critical-thinking-plugin/cmd/critical-thinking@latest`, that's `$GOPATH/bin/critical-thinking` — make sure `$GOPATH/bin` is on `$PATH`, or use the absolute path in the `command` field.
+All snippets assume the binary `critical-thinking` is on your `$PATH`. After `go install github.com/jacaudi/critical-thinking-mcp/cmd/critical-thinking@latest`, that's `$GOPATH/bin/critical-thinking` — make sure `$GOPATH/bin` is on `$PATH`, or use the absolute path in the `command` field.
 
 ## Claude Code
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,17 @@
 
 Cumulative breaking-change log for `critical-thinking`. Most recent changes first.
 
+## Repo rename: `critical-thinking-plugin` → `critical-thinking-mcp`
+
+The repo was renamed to drop the `-plugin` suffix, since the Claude Code plugin scaffolding was removed and the project is now solely an MCP server.
+
+- **GitHub repo** is now `jacaudi/critical-thinking-mcp`. GitHub redirects keep the old URL working, but new bookmarks and CI references should use the new name.
+- **Go module path** is now `github.com/jacaudi/critical-thinking-mcp`. Update import paths if you depend on `internal/thinking` from outside this repo.
+- **`go install`** is now `go install github.com/jacaudi/critical-thinking-mcp/cmd/critical-thinking@latest`. The binary still lands at `$GOPATH/bin/critical-thinking`.
+- **Docker image** unchanged: `ghcr.io/jacaudi/critical-thinking:<tag>` (the image name was already decoupled from the repo name).
+- **Binary, MCP `Implementation.Name`, and server log line** unchanged: `critical-thinking`.
+- **Client-side server aliases** (the key under `mcpServers` in `mcp.json`) are user-controlled and unaffected.
+
 ## Project rename: `rubber-ducky-mcp` → `critical-thinking`
 
 The whole project was renamed to align with the discipline it teaches. Specifics:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jacaudi/critical-thinking-plugin
+module github.com/jacaudi/critical-thinking-mcp
 
 go 1.26
 


### PR DESCRIPTION
## Summary

- Repo was renamed `critical-thinking-plugin` → `critical-thinking-mcp` to match the actual deliverable now that the plugin scaffolding is gone.
- Updates the Go module path, all import sites, the README H1, the `go install` examples in README and `docs/clients.md`, the Dockerfile `image.source` label, and the `release.yml` comment.
- Adds a new top-of-list section to `docs/migration.md` describing the rename; historical sections left intact.

## BREAKING CHANGE

External consumers of `internal/thinking` must update import paths to `github.com/jacaudi/critical-thinking-mcp`. GitHub keeps the old repo URL working via redirect, but Go module paths do not redirect — pinned dependencies will need a bump.

Per `.releaserc.json` rules (`breaking: true → minor`), merging this will cut a new minor release (e.g. `v1.3.0`) and tag a corresponding container image.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...`
- [ ] CI green on the PR
- [ ] Post-merge: confirm goreleaser run + `ghcr.io/jacaudi/critical-thinking:v1.3.0` published

🤖 Generated with [Claude Code](https://claude.com/claude-code)