### PR TITLE
refactor!: drop -mcp suffix from repo name and module path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,7 @@ jobs:
           echo "minor=$(echo "$VERSION" | cut -d. -f1-2)" >> "$GITHUB_OUTPUT"
 
   # Build and push the multi-arch container image with the full set of
-  # version tags. Image name decouples from the repo name (which carries the
-  # `-mcp` suffix) so users pull `ghcr.io/jacaudi/critical-thinking`.
+  # version tags. Image and repo names now match: `ghcr.io/jacaudi/critical-thinking`.
   container-image:
     needs: [release, version-parts]
     if: needs.release.outputs.new-release-published == 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.description="MCP server for critical, narrated, s
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.created="${BUILDTIME}"
 LABEL org.opencontainers.image.revision="${REVISION}"
-LABEL org.opencontainers.image.source="https://github.com/jacaudi/critical-thinking-mcp"
+LABEL org.opencontainers.image.source="https://github.com/jacaudi/critical-thinking"
 
 ENV DOCKER=true
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The single tool is `criticalthinking`. Every call must include the four critical
 ## Install
 
 ```bash
-go install github.com/jacaudi/critical-thinking-mcp/cmd/critical-thinking@latest
+go install github.com/jacaudi/critical-thinking/cmd/critical-thinking@latest
 # or
 docker pull ghcr.io/jacaudi/critical-thinking:v1.3.1
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Critical Thinking MCP
+# Critical Thinking
 
 A Model Context Protocol server for **critical, narrated, sequential thinking**. Think one step at a time, out loud — with required confidence calibration and adversarial self-critique on every thought.
 

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -14,7 +14,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/jacaudi/critical-thinking-mcp/internal/thinking"
+	"github.com/jacaudi/critical-thinking/internal/thinking"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/jacaudi/critical-thinking-mcp/internal/thinking"
+	"github.com/jacaudi/critical-thinking/internal/thinking"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -1,6 +1,6 @@
 # Client setup
 
-All snippets assume the binary `critical-thinking` is on your `$PATH`. After `go install github.com/jacaudi/critical-thinking-mcp/cmd/critical-thinking@latest`, that's `$GOPATH/bin/critical-thinking` — make sure `$GOPATH/bin` is on `$PATH`, or use the absolute path in the `command` field.
+All snippets assume the binary `critical-thinking` is on your `$PATH`. After `go install github.com/jacaudi/critical-thinking/cmd/critical-thinking@latest`, that's `$GOPATH/bin/critical-thinking` — make sure `$GOPATH/bin` is on `$PATH`, or use the absolute path in the `command` field.
 
 ## Claude Code
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,15 @@
 
 Cumulative breaking-change log for `critical-thinking`. Most recent changes first.
 
+## Repo rename: `critical-thinking-mcp` → `critical-thinking`
+
+The repo was renamed to drop the `-mcp` suffix and align with the upstream `sequentialthinking` MCP server naming. The image, binary, and tool name were already unsuffixed; the repo and module path now match.
+
+- **GitHub repo** is now `jacaudi/critical-thinking`. GitHub redirects keep the old `critical-thinking-mcp` URL working.
+- **Go module path** is now `github.com/jacaudi/critical-thinking`. Update import paths if you depend on `internal/thinking` from outside this repo — `go install` against the old path will fail (Go module paths do not redirect).
+- **`go install`** is now `go install github.com/jacaudi/critical-thinking/cmd/critical-thinking@latest`. The binary still lands at `$GOPATH/bin/critical-thinking`.
+- **Docker image, binary name, MCP `Implementation.Name`, server log line, and `mcp.json` server alias** all unchanged: `critical-thinking`.
+
 ## Repo rename: `critical-thinking-plugin` → `critical-thinking-mcp`
 
 The repo was renamed to drop the `-plugin` suffix, since the Claude Code plugin scaffolding was removed and the project is now solely an MCP server.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jacaudi/critical-thinking-mcp
+module github.com/jacaudi/critical-thinking
 
 go 1.26.3
 


### PR DESCRIPTION
## Summary

- Repo renamed `critical-thinking-mcp` → `critical-thinking` to match upstream `sequentialthinking` MCP server naming. The image, binary, tool name, and MCP `Implementation.Name` were already unsuffixed.
- Updates the Go module path, all import sites, README/`docs/clients.md` `go install` examples, the Dockerfile `image.source` label, and the `release.yml` comment.
- Adds a new top-of-list section to `docs/migration.md`; prior sections kept intact.

## BREAKING CHANGE

External consumers of `internal/thinking` must update import paths to `github.com/jacaudi/critical-thinking`. GitHub keeps the old repo URL working via redirect; Go module paths do not redirect, so pinned dependencies need bumping.

Per `.releaserc.json` rules (`breaking: true → minor`), merging this will cut a new minor release (`v1.4.0`) and tag a corresponding container image.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...`
- [ ] CI green on the PR
- [ ] Post-merge: confirm goreleaser run + `ghcr.io/jacaudi/critical-thinking:v1.4.0` published

🤖 Generated with [Claude Code](https://claude.com/claude-code)