### PR TITLE
fix(release): use conventionalcommits preset so chore(deps) shows in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       use-github-app: true
       go: true
       goreleaser: true
-      extra-plugins: '@semantic-release/changelog @semantic-release/git @semantic-release/exec'
+      extra-plugins: '@semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog-conventionalcommits'
     secrets:
       app-id: ${{ secrets.BOT_APP_ID }}
       app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,6 +10,7 @@
       ]
     }],
     ["@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits",
       "presetConfig": {
         "types": [
           { "type": "feat",     "section": "Features" },


### PR DESCRIPTION
## Summary

The release-notes-generator was implicitly defaulting to the **angular** preset, which hides \`chore\` commits regardless of \`presetConfig.types\` overrides. The v1.3.1 and v1.4.1 release bodies were empty under the version header because every commit in those releases was \`chore(deps)\`.

This PR switches to the **conventionalcommits** preset, which honors \`presetConfig.types\` properly — \`chore(deps)\` entries will now appear under a "Dependencies" section in subsequent releases.

## Changes

- \`.releaserc.json\` — adds \`"preset": "conventionalcommits"\` to the \`@semantic-release/release-notes-generator\` block.
- \`.github/workflows/release.yml\` — adds \`conventional-changelog-conventionalcommits\` to \`extra-plugins\` so the CI installs the preset package alongside the other semantic-release add-ons.

## Verification

The fix is testable in production: merging this PR triggers a \`v1.4.2\` patch release whose changelog body should list this very commit under "Bug Fixes". If the body comes back empty again, the fix didn't apply and we'll need to dig deeper into the reusable workflow's plugin install path.

## Test plan

- [ ] CI green on the PR
- [ ] After merge: \`v1.4.2\` release body shows this \`fix(release)\` commit under "Bug Fixes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)