### PR TITLE
feat: add -cli streaming mode and schema subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ critical-thinking -http :3000
 
 # Docker (HTTP on :3000)
 docker run --rm -p 3000:3000 ghcr.io/jacaudi/critical-thinking:v1.4.2
+
+# CLI mode — pipe NDJSON ThoughtData directly, no MCP host required
+critical-thinking -cli            # prints narrated transcript to stdout
+critical-thinking -cli -json      # prints structured ThoughtResponse as NDJSON
+critical-thinking schema          # prints the tool contract (description + JSON Schemas) and exits
 ```
+
+See [docs/clients.md#cli-no-mcp-host](docs/clients.md#cli-no-mcp-host) for CLI usage details and error-handling behaviour.
 
 ## One-call example
 

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -46,8 +46,12 @@ type toolDescriptor struct {
 // printSchema writes the criticalthinking tool contract (description + JSON
 // Schemas) to w as pretty JSON. Schemas come from jsonschema.For[T](nil),
 // which defaults to &jsonschema.ForOptions{} — the same call the MCP SDK makes
-// internally (jsonschema.ForType(rt, &jsonschema.ForOptions{})), so the CLI
-// and the MCP transport advertise the identical wire schema.
+// internally (jsonschema.ForType(rt, &jsonschema.ForOptions{})). The
+// inputSchema is therefore byte-identical to what MCP clients receive in
+// tools/list. The outputSchema is what the SDK would generate for
+// ThoughtResponse (and what the tool's structuredContent conforms to); the
+// MCP tool itself advertises no output schema, since its handler output type
+// is `any`.
 func printSchema(w io.Writer) error {
 	in, err := jsonschema.For[thinking.ThoughtData](nil)
 	if err != nil {

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -76,13 +78,72 @@ func main() {
 		os.Exit(0)
 	}
 
+	cliMode := flag.Bool("cli", false, "read NDJSON ThoughtData on stdin and stream transcripts (no MCP)")
+	jsonOut := flag.Bool("json", false, "with -cli, emit structured ThoughtResponse as NDJSON instead of the transcript")
 	flag.Parse()
 
-	if *httpAddr == "" {
+	switch {
+	case *cliMode:
+		os.Exit(runCLI(os.Stdin, os.Stdout, os.Stderr, *jsonOut))
+	case *httpAddr != "":
+		runHTTP(*httpAddr)
+	default:
 		runStdio()
-		return
 	}
-	runHTTP(*httpAddr)
+}
+
+// runCLI runs the thinking engine over a plain stdin→stdout loop (no MCP).
+// One in-memory thinking.NewServer() lives for the call, so history,
+// confidence, and branches accumulate across input lines — the analog of a
+// stdio MCP session. Input is NDJSON: one ThoughtData per non-blank line.
+// Returns 0 if every line succeeded, 1 if any line errored.
+func runCLI(stdin io.Reader, stdout, stderr io.Writer, jsonOut bool) int {
+	state := thinking.NewServer()
+	sc := bufio.NewScanner(stdin)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // tolerate long thoughts
+	lineNo := 0
+	failed := false
+	for sc.Scan() {
+		lineNo++
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var td thinking.ThoughtData
+		if err := json.Unmarshal(line, &td); err != nil {
+			fmt.Fprintf(stderr, "cli: line %d: %v\n", lineNo, err)
+			failed = true
+			continue
+		}
+		res, err := state.ProcessThought(td)
+		if err != nil {
+			fmt.Fprintf(stderr, "cli: line %d: %v\n", lineNo, err)
+			failed = true
+			continue
+		}
+		if res.IsError {
+			failed = true
+			if jsonOut {
+				fmt.Fprintln(stdout, res.Text) // error JSON keeps NDJSON aligned
+			} else {
+				fmt.Fprintln(stderr, res.Text)
+			}
+			continue
+		}
+		if jsonOut {
+			fmt.Fprintln(stdout, res.StructuredJSON)
+		} else {
+			fmt.Fprintf(stdout, "%s\n\n", res.Text)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		fmt.Fprintf(stderr, "cli: read: %v\n", err)
+		return 1
+	}
+	if failed {
+		return 1
+	}
+	return 0
 }
 
 // runStdio runs the server with one global SequentialThinkingServer instance.

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -14,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/jacaudi/critical-thinking/internal/thinking"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -29,7 +32,50 @@ const (
 	shutdownGrace = 10 * time.Second
 )
 
+// toolDescriptor mirrors what MCP clients receive via tools/list, so a model
+// driving the CLI sees the same contract.
+type toolDescriptor struct {
+	Name         string             `json:"name"`
+	Description  string             `json:"description"`
+	InputSchema  *jsonschema.Schema `json:"inputSchema"`
+	OutputSchema *jsonschema.Schema `json:"outputSchema"`
+}
+
+// printSchema writes the criticalthinking tool contract (description + JSON
+// Schemas) to w as pretty JSON. Schemas come from jsonschema.For[T](nil),
+// which defaults to &jsonschema.ForOptions{} — the same call the MCP SDK makes
+// internally (jsonschema.ForType(rt, &jsonschema.ForOptions{})), so the CLI
+// and the MCP transport advertise the identical wire schema.
+func printSchema(w io.Writer) error {
+	in, err := jsonschema.For[thinking.ThoughtData](nil)
+	if err != nil {
+		return fmt.Errorf("input schema: %w", err)
+	}
+	out, err := jsonschema.For[thinking.ThoughtResponse](nil)
+	if err != nil {
+		return fmt.Errorf("output schema: %w", err)
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(toolDescriptor{
+		Name:         "criticalthinking",
+		Description:  thinking.ToolDescription,
+		InputSchema:  in,
+		OutputSchema: out,
+	})
+}
+
 func main() {
+	// `schema` subcommand: print the tool contract and exit. Checked before
+	// flag.Parse so the bare word isn't treated as a flag-parse error.
+	if len(os.Args) > 1 && os.Args[1] == "schema" {
+		if err := printSchema(os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, "schema:", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	flag.Parse()
 
 	if *httpAddr == "" {

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -82,6 +82,11 @@ func main() {
 	jsonOut := flag.Bool("json", false, "with -cli, emit structured ThoughtResponse as NDJSON instead of the transcript")
 	flag.Parse()
 
+	if *jsonOut && !*cliMode {
+		fmt.Fprintln(os.Stderr, "cli: -json requires -cli")
+		os.Exit(1)
+	}
+
 	switch {
 	case *cliMode:
 		os.Exit(runCLI(os.Stdin, os.Stdout, os.Stderr, *jsonOut))

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -400,8 +400,8 @@ func TestRunCLIValidationErrorRouting(t *testing.T) {
 	if code := runCLI(strings.NewReader(bad), &out2, &errb2, true); code != 1 {
 		t.Errorf("json mode exit = %d; want 1", code)
 	}
-	if !strings.Contains(out2.String(), `"status":"failed"`) {
-		t.Errorf("json: error JSON should go to stdout; out=%q", out2.String())
+	if !strings.Contains(out2.String(), `"status":"failed"`) || errb2.Len() != 0 {
+		t.Errorf("json: error JSON should go to stdout only; out=%q err=%q", out2.String(), errb2.String())
 	}
 }
 

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -330,6 +330,26 @@ func TestPrintSchema(t *testing.T) {
 	}
 }
 
+func TestRunCLITranscriptAndAccumulation(t *testing.T) {
+	in := strings.Join([]string{
+		`{"thought":"first","thoughtNumber":1,"totalThoughts":2,"nextThoughtNeeded":true,"confidence":0.5,"assumptions":[],"critique":"c","counterArgument":"ca","nextStepRationale":"continue"}`,
+		`{"thought":"second","thoughtNumber":2,"totalThoughts":2,"nextThoughtNeeded":false,"confidence":0.7,"assumptions":[],"critique":"c2","counterArgument":"ca2"}`,
+	}, "\n") + "\n"
+
+	var out, errb bytes.Buffer
+	code := runCLI(strings.NewReader(in), &out, &errb, false)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, errb.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "Thought 1 of 2") || !strings.Contains(s, "Thought 2 of 2") {
+		t.Errorf("missing thought headers:\n%s", s)
+	}
+	if !strings.Contains(s, "across 2 thoughts") {
+		t.Errorf("expected accumulated footer 'across 2 thoughts':\n%s", s)
+	}
+}
+
 func TestThinkingCurrentResourceIsPerSession(t *testing.T) {
 	registry := newSessionRegistry()
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -366,6 +366,52 @@ func TestRunCLITranscriptAndAccumulation(t *testing.T) {
 	}
 }
 
+func TestRunCLIMalformedLineContinues(t *testing.T) {
+	in := "{not json\n" +
+		`{"thought":"ok","thoughtNumber":1,"totalThoughts":1,"nextThoughtNeeded":false,"confidence":0.5,"assumptions":[],"critique":"c","counterArgument":"ca"}` + "\n"
+	var out, errb bytes.Buffer
+	code := runCLI(strings.NewReader(in), &out, &errb, false)
+	if code != 1 {
+		t.Errorf("exit = %d; want 1", code)
+	}
+	if !strings.Contains(errb.String(), "line 1") {
+		t.Errorf("stderr should reference line 1: %q", errb.String())
+	}
+	if !strings.Contains(out.String(), "Thought 1 of 1") {
+		t.Errorf("a valid line after a bad one must still render:\n%s", out.String())
+	}
+}
+
+func TestRunCLIValidationErrorRouting(t *testing.T) {
+	// Missing required "critique" → validation error result (IsError).
+	bad := `{"thought":"x","thoughtNumber":1,"totalThoughts":1,"nextThoughtNeeded":false,"confidence":0.5,"assumptions":[],"counterArgument":"ca"}` + "\n"
+
+	// default mode: error JSON to stderr, nothing to stdout.
+	var out, errb bytes.Buffer
+	if code := runCLI(strings.NewReader(bad), &out, &errb, false); code != 1 {
+		t.Errorf("default mode exit = %d; want 1", code)
+	}
+	if out.Len() != 0 || !strings.Contains(errb.String(), `"status":"failed"`) {
+		t.Errorf("default: want error JSON on stderr only; out=%q err=%q", out.String(), errb.String())
+	}
+
+	// -json mode: error JSON to stdout (keeps the NDJSON stream complete).
+	var out2, errb2 bytes.Buffer
+	if code := runCLI(strings.NewReader(bad), &out2, &errb2, true); code != 1 {
+		t.Errorf("json mode exit = %d; want 1", code)
+	}
+	if !strings.Contains(out2.String(), `"status":"failed"`) {
+		t.Errorf("json: error JSON should go to stdout; out=%q", out2.String())
+	}
+}
+
+func TestRunCLIBlankAndEmpty(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runCLI(strings.NewReader("\n   \n"), &out, &errb, false); code != 0 || out.Len() != 0 {
+		t.Errorf("blank/empty: code=%d out=%q", code, out.String())
+	}
+}
+
 func TestThinkingCurrentResourceIsPerSession(t *testing.T) {
 	registry := newSessionRegistry()
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -325,8 +325,24 @@ func TestPrintSchema(t *testing.T) {
 	if !bytes.Contains(d.InputSchema, []byte(`"thought"`)) {
 		t.Errorf("inputSchema missing the 'thought' property: %s", d.InputSchema)
 	}
-	if len(d.OutputSchema) == 0 || string(d.OutputSchema) == "null" {
-		t.Errorf("outputSchema missing: %s", d.OutputSchema)
+	if !bytes.Contains(d.OutputSchema, []byte(`"sessionConfidence"`)) {
+		t.Errorf("outputSchema missing the 'sessionConfidence' property: %s", d.OutputSchema)
+	}
+}
+
+func TestRunCLIJSONOutput(t *testing.T) {
+	in := `{"thought":"x","thoughtNumber":1,"totalThoughts":1,"nextThoughtNeeded":false,"confidence":0.5,"assumptions":[],"critique":"c","counterArgument":"ca"}` + "\n"
+	var out, errb bytes.Buffer
+	code := runCLI(strings.NewReader(in), &out, &errb, true)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, errb.String())
+	}
+	var resp thinking.ThoughtResponse
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp); err != nil {
+		t.Fatalf("stdout is not NDJSON ThoughtResponse: %v\n%s", err, out.String())
+	}
+	if resp.ThoughtNumber != 1 || resp.ThoughtHistoryLength != 1 {
+		t.Errorf("resp = %+v", resp)
 	}
 }
 

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -302,6 +302,34 @@ func TestCrossSessionIsolation(t *testing.T) {
 	}
 }
 
+func TestPrintSchema(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printSchema(&buf); err != nil {
+		t.Fatalf("printSchema: %v", err)
+	}
+	var d struct {
+		Name         string          `json:"name"`
+		Description  string          `json:"description"`
+		InputSchema  json.RawMessage `json:"inputSchema"`
+		OutputSchema json.RawMessage `json:"outputSchema"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &d); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if d.Name != "criticalthinking" {
+		t.Errorf("name = %q; want criticalthinking", d.Name)
+	}
+	if d.Description != thinking.ToolDescription {
+		t.Error("description does not match thinking.ToolDescription")
+	}
+	if !bytes.Contains(d.InputSchema, []byte(`"thought"`)) {
+		t.Errorf("inputSchema missing the 'thought' property: %s", d.InputSchema)
+	}
+	if len(d.OutputSchema) == 0 || string(d.OutputSchema) == "null" {
+		t.Errorf("outputSchema missing: %s", d.OutputSchema)
+	}
+}
+
 func TestThinkingCurrentResourceIsPerSession(t *testing.T) {
 	registry := newSessionRegistry()
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -121,3 +121,24 @@ docker run -d --name critical-thinking -p 3000:3000 ghcr.io/jacaudi/critical-thi
 ```
 
 Then use the HTTP client config above. The image binds to `0.0.0.0` automatically (via `DOCKER=true`); pair it with appropriate firewall rules in production.
+
+## CLI (no MCP host)
+
+Run the engine directly, without an MCP client:
+
+```bash
+# Stream thoughts: one ThoughtData JSON object per line on stdin.
+printf '%s\n' '{"thought":"...","thoughtNumber":1,"totalThoughts":3,"nextThoughtNeeded":true,"confidence":0.6,"assumptions":[],"critique":"...","counterArgument":"...","nextStepRationale":"..."}' \
+  | critical-thinking -cli
+
+# Structured NDJSON output instead of the transcript:
+... | critical-thinking -cli -json
+
+# Print the tool contract (description + JSON Schemas) for a model to read:
+critical-thinking schema
+```
+
+`-cli` keeps one in-memory session for the process, so history, confidence, and
+branches accumulate across input lines. Validation/parse errors are written to
+stderr (or to stdout in `-json` mode, to keep the stream complete) and the
+process continues; the exit code is `1` if any line errored, else `0`.

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/jacaudi/critical-thinking
 
 go 1.26.3
 
-require github.com/modelcontextprotocol/go-sdk v1.6.0
+require (
+	github.com/google/jsonschema-go v0.4.3
+	github.com/modelcontextprotocol/go-sdk v1.6.0
+)
 
 require (
-	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,8 @@ github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63Y
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
-github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
 github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
-github.com/modelcontextprotocol/go-sdk v1.5.0 h1:CHU0FIX9kpueNkxuYtfYQn1Z0slhFzBZuq+x6IiblIU=
-github.com/modelcontextprotocol/go-sdk v1.5.0/go.mod h1:gggDIhoemhWs3BGkGwd1umzEXCEMMvAnhTrnbXJKKKA=
 github.com/modelcontextprotocol/go-sdk v1.6.0 h1:PPLS3kn7WtOEnR+Af4X5H96SG0qSab8R/ZQT/HkhPkY=
 github.com/modelcontextprotocol/go-sdk v1.6.0/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=


### PR DESCRIPTION
## Summary

Adds two non-MCP entry points to the binary, with **zero changes to the `internal/thinking` engine**:

- **`-cli` streaming mode** — reads NDJSON (`one ThoughtData` JSON object per line) on stdin and keeps one in-memory session for the process, so history, confidence, and branches accumulate across lines (the analog of a stdio MCP session). Prints each thought's narrated transcript, or the structured `ThoughtResponse` as NDJSON with `-json`. Continue-on-error (validation/parse errors → stderr, or stdout in `-json` mode to keep the stream complete); exits `1` if any line errored, else `0`.
- **`schema` subcommand** — prints `{name, description, inputSchema, outputSchema}` as JSON so a model can learn the input contract. Schemas are generated with `jsonschema.For[T](nil)`, which matches the MCP SDK's internal `jsonschema.ForType(rt, &jsonschema.ForOptions{})` — so the `inputSchema` is byte-identical to what MCP clients receive in `tools/list`.
- **Dispatch precedence** in `main()`: `schema` → `-cli` → `-http` → stdio (existing stdio + `-http` MCP transports unaffected). `-json` without `-cli` exits `1` with a clear message.

All additions live in `cmd/critical-thinking/main.go`; `jsonschema-go` is promoted from an indirect to a direct dependency.

## Test Plan

- [x] `go test ./...` passes (engine ~97% / cmd ~61% coverage); `go vet ./...` and `gofmt -l .` clean
- [x] Independent review: live `tools/list` schema-parity check, multi-thought accumulation, error routing both directions, scanner buffer limits (500KB ok / 2MB rejected)
- [x] Manual smoke on the compiled binary: `schema` (valid JSON, all 4 keys, `inputSchema.thought` + `outputSchema.sessionConfidence` present), `-cli` (two-thought accumulation 0.60→0.75), `-cli -json` (NDJSON, history 1→2), `-json` without `-cli` → exit 1, malformed line → stderr + continue + exit 1, validation error in `-json` → error JSON to stdout + exit 1

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)
