### PR TITLE
build: standards refactor phase 0 - tooling, lint, modern-Go, zero behavior change

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -10,6 +10,12 @@ runs:
         go-version: '1.26'
         cache: true
 
+    - name: Setup Task
+      uses: arduino/setup-task@v2
+      with:
+        version: 3.x
+        repo-token: ${{ github.token }}
+
     - name: gofmt -d
       shell: bash
       run: |
@@ -21,14 +27,23 @@ runs:
           exit 1
         fi
 
-    - name: go vet
+    - name: vet
       shell: bash
-      run: go vet ./...
+      run: task vet
 
-    - name: go test -race
-      shell: bash
-      run: go test -race -coverprofile=coverage.txt ./...
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v6
+      with:
+        version: latest
 
-    - name: go build
+    - name: govulncheck
       shell: bash
-      run: go build -trimpath -ldflags "-s -w" -o /tmp/critical-thinking ./cmd/critical-thinking
+      run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+    - name: test (race + coverage)
+      shell: bash
+      run: task test-race
+
+    - name: build
+      shell: bash
+      run: task build

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,5 @@ coverage.txt
 
 # Working/agent-only documents (not committed to repo)
 docs/codebase-review.md
-docs/plans/2025-11-21-go-multiuser-sequential-thinking.md
-docs/plans/2026-04-25-rubber-ducky-mcp-design.md
-docs/plans/2026-04-25-rubber-ducky-mcp-implementation.md
-docs/plans/2026-05-05-rubber-duck-skill-design.md
-docs/plans/2026-05-05-rubber-duck-skill-implementation.md
+docs/plans/
+docs/prompts/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+version: "2"
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - gosec
+    - unused
+    - gocritic

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,8 @@ builds:
     ldflags:
       - -s -w
       - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 go build \
     -trimpath \
-    -ldflags "-s -w -X main.version=${VERSION}" \
+    -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" \
     -o /out/critical-thinking ./cmd/critical-thinking
 
 # ---- final ----

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -26,8 +26,11 @@ import (
 // Injected at build time via -ldflags (see taskfile.yml / .goreleaser.yaml / Dockerfile).
 var (
 	version = "dev"
-	commit  = "unknown"
-	date    = "unknown"
+	// commit and date are populated by -ldflags but not yet read in code;
+	// consumption is wired up in a later task. Keep the vars so the build-time
+	// injection has a target.
+	commit = "unknown" //nolint:unused // set via -ldflags; consumed in a later task
+	date   = "unknown" //nolint:unused // set via -ldflags; consumed in a later task
 )
 
 var httpAddr = flag.String("http", "", "if set (e.g., \":3000\"), serve Streamable HTTP at this address; otherwise use stdio")
@@ -122,34 +125,36 @@ func runCLI(stdin io.Reader, stdout, stderr io.Writer, jsonOut bool) int {
 			continue
 		}
 		var td thinking.ThoughtData
+		// Write errors on stdout/stderr aren't actionable here; the exit code
+		// already reflects per-line success via failed.
 		if err := json.Unmarshal(line, &td); err != nil {
-			fmt.Fprintf(stderr, "cli: line %d: %v\n", lineNo, err)
+			_, _ = fmt.Fprintf(stderr, "cli: line %d: %v\n", lineNo, err)
 			failed = true
 			continue
 		}
 		res, err := state.ProcessThought(td)
 		if err != nil {
-			fmt.Fprintf(stderr, "cli: line %d: %v\n", lineNo, err)
+			_, _ = fmt.Fprintf(stderr, "cli: line %d: %v\n", lineNo, err)
 			failed = true
 			continue
 		}
 		if res.IsError {
 			failed = true
 			if jsonOut {
-				fmt.Fprintln(stdout, res.Text) // error JSON keeps NDJSON aligned
+				_, _ = fmt.Fprintln(stdout, res.Text) // error JSON keeps NDJSON aligned
 			} else {
-				fmt.Fprintln(stderr, res.Text)
+				_, _ = fmt.Fprintln(stderr, res.Text)
 			}
 			continue
 		}
 		if jsonOut {
-			fmt.Fprintln(stdout, res.StructuredJSON)
+			_, _ = fmt.Fprintln(stdout, res.StructuredJSON)
 		} else {
-			fmt.Fprintf(stdout, "%s\n\n", res.Text)
+			_, _ = fmt.Fprintf(stdout, "%s\n\n", res.Text)
 		}
 	}
 	if err := sc.Err(); err != nil {
-		fmt.Fprintf(stderr, "cli: read: %v\n", err)
+		_, _ = fmt.Fprintf(stderr, "cli: read: %v\n", err)
 		return 1
 	}
 	if failed {
@@ -186,21 +191,22 @@ func runStdio() {
 // the SDK closes a session we have no callback, so the count drifts upward.
 // /health exposes it as `sessionsCreated` to make the semantics explicit.
 func runHTTP(addr string) {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
-
-	registry := newSessionRegistry()
-
 	// Wire ALLOWED_ORIGINS into the SDK's CSRF protection so browser clients
 	// from those origins aren't rejected by the SDK's default same-origin
 	// policy. Non-browser callers (no Origin / no Sec-Fetch-Site) are still
-	// allowed regardless.
+	// allowed regardless. Built before the signal context's defer stop() is
+	// registered so a fatal config error here can't skip a pending defer.
 	csrf := http.NewCrossOriginProtection()
 	for _, o := range parseAllowedOrigins(os.Getenv("ALLOWED_ORIGINS")) {
 		if err := csrf.AddTrustedOrigin(o); err != nil {
 			log.Fatalf("invalid ALLOWED_ORIGINS entry %q: %v", o, err)
 		}
 	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	registry := newSessionRegistry()
 
 	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		state := thinking.NewServer()
@@ -239,6 +245,9 @@ func runHTTP(addr string) {
 
 	log.Printf("critical-thinking %s listening on http://%s", version, listenAddr)
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		// nolint:gocritic // defer stop() only unregisters signal handlers and is
+		// moot at process exit; the alternatives (return / os.Exit) would change the
+		// non-zero exit code or require refactoring runHTTP's signature.
 		log.Fatalf("listen: %v", err)
 	}
 }

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -23,9 +23,12 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// version is set at build time via -ldflags "-X main.version=...". The
-// fallback "dev" identifies non-release builds.
-var version = "dev"
+// Injected at build time via -ldflags (see taskfile.yml / .goreleaser.yaml / Dockerfile).
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+)
 
 var httpAddr = flag.String("http", "", "if set (e.g., \":3000\"), serve Streamable HTTP at this address; otherwise use stdio")
 

--- a/cmd/critical-thinking/main.go
+++ b/cmd/critical-thinking/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -375,7 +376,7 @@ func withCORS(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
 		if origin != "" {
-			if !contains(allowed, origin) {
+			if !slices.Contains(allowed, origin) {
 				http.Error(w, "Origin not allowed", http.StatusForbidden)
 				return
 			}
@@ -408,15 +409,6 @@ func parseAllowedOrigins(raw string) []string {
 		}
 	}
 	return out
-}
-
-func contains(haystack []string, needle string) bool {
-	for _, h := range haystack {
-		if h == needle {
-			return true
-		}
-	}
-	return false
 }
 
 func makeHealthHandler(r *sessionRegistry) http.HandlerFunc {

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -267,20 +267,17 @@ func TestCrossSessionIsolation(t *testing.T) {
 	// Drive 10 thoughts through each, interleaved.
 	const N = 10
 	var wg sync.WaitGroup
-	wg.Add(2)
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := 1; i <= N; i++ {
 			clientA.callTool(t, validInputN(i, "A"))
 		}
-	}()
-	go func() {
-		defer wg.Done()
+	})
+	wg.Go(func() {
 		for i := 1; i <= N; i++ {
 			clientB.callTool(t, validInputN(i, "B"))
 		}
-	}()
+	})
 	wg.Wait()
 
 	// Final call on each session: assert each only sees its own thoughts.

--- a/cmd/critical-thinking/main_test.go
+++ b/cmd/critical-thinking/main_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,8 +32,7 @@ func TestCORSDefaultRejectsBrowser(t *testing.T) {
 }
 
 func TestCORSAllowsConfiguredOrigin(t *testing.T) {
-	os.Setenv("ALLOWED_ORIGINS", "https://app.example,https://other.example")
-	defer os.Unsetenv("ALLOWED_ORIGINS")
+	t.Setenv("ALLOWED_ORIGINS", "https://app.example,https://other.example")
 
 	h := withCORS(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -203,7 +201,7 @@ func (c *httpClient) post(t *testing.T, payload string, withSession bool) (*http
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	body, _ := io.ReadAll(resp.Body)
 	return resp, string(body)
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,7 +50,6 @@ The inspector lets you call `criticalthinking` interactively, watch the rendered
 │   ├── server.go                 # SequentialThinkingServer state machine
 │   └── *_test.go                 # unit tests
 ├── Dockerfile                    # multi-stage, distroless final
-└── docker-bake.hcl               # buildx bake config
 ```
 
 The `internal/thinking` package has zero dependency on the MCP SDK — `cmd/critical-thinking/main.go` is the only adapter. That keeps the state machine fully unit-testable.

--- a/docs/history/codebase-review-typescript.md
+++ b/docs/history/codebase-review-typescript.md
@@ -1,0 +1,260 @@
+> Historical: review of the predecessor TypeScript implementation, pre-Go-rewrite.
+
+# Comprehensive Code Review — `http-sequential-thinking`
+
+**Branch:** `claude/codebase-review-OnQKR` · **Version:** 0.6.2 · **Server name advertised:** `sequential-thinking-server` `0.2.0`
+
+A small but production-leaning MCP server (Streamable HTTP). The code is generally clean, but there are real correctness, dead-code, and config issues. Findings are grouped by file and tagged **🔴 Bug · 🟠 Risk · 🟡 Smell · 🔵 Note**.
+
+---
+
+## `index.ts` (entry point — 356 lines)
+
+### 🔴 Bugs / correctness
+
+- **L17 — Unused import `ThoughtData`.** Only `SequentialThinkingServer` is referenced. Dead import.
+- **L9 — Unused import `InitializeRequestSchema`.** Never referenced.
+- **L181–263 — Single shared `Server` connected to many transports.** `server.connect(transport)` is called every time a *new* session initializes (L263), reusing the same `Server` instance. The MCP SDK's `Server` is normally one-transport-per-server; calling `connect()` repeatedly mutates internal transport state and does not cleanly fan out across sessions. The pattern that actually works is either (a) one `Server` per session, instantiated inside `onsessioninitialized`, or (b) one transport that natively multiplexes sessions. As written, only the most-recently-connected session is reliably routed. Verify against the SDK version pinned (`@modelcontextprotocol/sdk ^1.22.0`) before shipping.
+- **L198–199 — `(transport as unknown as StreamableHTTPServerTransport)`.** The second handler arg is `RequestHandlerExtra`, not the transport. `RequestHandlerExtra.sessionId` exists, so the cast happens to read the right field, but the type assertion is misleading and will silently break if the field name moves. Replace with the proper `extra.sessionId` access (and drop the cast).
+- **L227 — `path.join(__dirname, '..', 'web', 'index.html')`.** Relies on the runtime layout being `dist/index.js` with `web/` as a sibling of `dist/`. Works for the published package and Docker, but breaks when running `ts-node index.ts` (then `__dirname` is the repo root and `..` escapes it). At minimum, comment the assumption.
+
+### 🟠 Risks
+
+- **L153 — Dev-mode origin wildcard.** When `NODE_ENV=development` and the request lacks an `Origin`, response is `Access-Control-Allow-Origin: *`. Combined with no auth, any local site can hit the server during dev. Acceptable for `127.0.0.1` only — but the same code path is reachable in Docker mode (`0.0.0.0`) if `NODE_ENV` is unset/dev. Tighten to: dev wildcard *only* when `host === '127.0.0.1'`.
+- **L139–141 — `ALLOWED_ORIGINS` not documented.** Defaults to `localhost:3000`/`127.0.0.1:3000`. If `PORT` is changed, the default origin list still references `:3000` and will reject the matching browser. Build the default from `port`.
+- **L144–170 — No `Access-Control-Expose-Headers: mcp-session-id`.** The browser client at `web/index.html` reads `response.headers.get('mcp-session-id')` (web/index.html:186). Same-origin works today; cross-origin (any deployment behind a reverse proxy on a different host) silently returns `null` and breaks session capture.
+- **L173 — `express.json()` with no `limit`.** Express 5 defaults to 100 KiB which is fine, but make it explicit so a future bump can't surprise you.
+- **L315–338 — `setInterval` is never cleared, no SIGTERM/SIGINT handler.** Process can't shut down gracefully; in-flight SSE streams are dropped and Docker `STOPSIGNAL` waits the grace period before force-killing.
+- **L318 — Cleanup loop logs only when `sessionCount > 0`** but iterates `for (const sessionId in sessionStates)` which is fine — except it relies on `transport.onclose` to delete entries (L254–260). If `onclose` is asynchronous and the next interval fires before it runs, the same session can be `close()`-d twice. Harmless for the SDK today, fragile.
+- **No rate limiting / no auth.** Anyone who can reach the port can spin up unlimited sessions — each session keeps an unbounded `thoughtHistory` for up to 60 minutes. Combined with no per-session size cap (see `SequentialThinkingServer` below), this is a memory-DoS surface. Document that the server is intended for trusted local use, or add a cap.
+
+### 🟡 Smells
+
+- **L136 — `DOCKER=true` switches binding to `0.0.0.0`.** Implicit env-as-config. A `--host` CLI flag (or `HOST` env) is more honest and works the same regardless of container.
+- **L156–157 — `console.error` for normal CORS rejections.** `error` channel is for actual errors; this floods stderr in production.
+- **L264–275 — “Bad Request” path includes initialize-without-method.** Reasonable, but a request with `req.body?.method !== 'initialize'` *and* an unknown session also lands here with the same generic error. A 404 for unknown session vs 400 for missing method would be clearer.
+- **L282–297 — `handleSessionRequest` accepts `?sessionId=` query for `EventSource` compatibility** but only updates `lastAccessed` on `GET`. `DELETE` should arguably touch it too (or not — it's terminating the session), but it's worth a one-line comment so the asymmetry isn't accidental.
+- **L341 — `app.listen(port, host, ...)`.** No error handler on `listen` (e.g. `EADDRINUSE`). The top-level `runServer().catch(...)` only catches if `listen` *throws*; the typical path emits an `'error'` event instead and silently keeps the loop alive.
+
+---
+
+## `src/SequentialThinkingServer.ts` (121 lines)
+
+### 🔴 Bugs / correctness
+
+- **L93 — `formattedThought` is computed and discarded.** This is the most concrete bug in the file. The README's "Privacy by Design — no sensitive tool inputs/outputs are logged" implies a deliberate removal of `console.error(formattedThought)`, but the call to `formatThought()` (and the entire method, ~25 lines) was left behind. Either delete `formatThought` and the call, or — if the formatted box is still useful for debugging — gate it behind a `DEBUG_THOUGHTS` env flag. As-is, it's pure waste plus an attack surface for the chalk import that brings ESM-test friction.
+- **L22 / L25 / L28 — Falsy guards reject legitimate values with misleading errors.**
+  - `!data.thought` rejects empty string with "must be a string" — it *is* a string. Should be `typeof data.thought !== 'string' || data.thought.length === 0`.
+  - `!data.thoughtNumber` rejects `0` with "must be a number" — it *is* a number. The schema requires `≥ 1`, so check that explicitly: `typeof x !== 'number' || x < 1`.
+  - Same for `!data.totalThoughts`.
+- **L40–44 — Optional fields cast without validation.** A client sending `revisesThought: "five"` is silently accepted; the value flows through `formatThought` into the rendered template. Add `typeof` checks (and number-range checks) to mirror the JSON Schema in `index.ts`.
+- **L66 / L72 — `formatThought` width math is wrong with chalk codes.** `header.length` includes ANSI escape codes from `chalk.yellow/green/blue`, but `border = '─'.repeat(...)` is meant to match *visible* width. Result: borders are wider than the visible header, and `thought.padEnd(border.length - 2)` over-pads by ~10 characters. Strip ANSI before measuring, or compose the visible string first then colorize. (Moot if the function is deleted — see above.)
+- **L86–91 — Branch is recorded only if both `branchFromThought` and `branchId` are present.** The schema permits either alone. Decide the contract and validate on entry, rather than silently dropping the branch.
+
+### 🟠 Risks
+
+- **No upper bound on `thoughtHistory` or `branches`.** A single misbehaving (or malicious) client can grow these arrays indefinitely within the 1-hour session window. Cap to e.g. 1000 thoughts and reject further pushes.
+- **Mutates the input on L80–82.** `validatedInput.totalThoughts = validatedInput.thoughtNumber` after `validateThoughtData` returned a *new* object — fine, but worth a comment explaining the auto-bump (the test at line 123 of the test file is the only documentation).
+
+### 🟡 Smells
+
+- **`processThought` return type is inline `{ content: Array<{ type: string; text: string }>; isError?: boolean }`.** The MCP SDK exports a `CallToolResult` type — using it gives compile-time checks against schema drift.
+- **`ThoughtData` exports both used and unused fields — `nextThoughtNeeded` is required at the type level but only read inside the JSON response.** Fine, but trim the interface to only what the class actually consumes.
+
+---
+
+## `tests/SequentialThinkingServer.test.ts` (192 lines)
+
+### 🟡 Coverage gaps
+
+- No test for `branchFromThought` *without* `branchId` (or vice-versa) — exactly the silent-drop edge case above.
+- No test for the optional-field type validation (sending `revisesThought: "x"` etc.) — validates the bug noted in `SequentialThinkingServer.ts`.
+- No test for `formatThought` directly. (Reasonable since it's private and likely should be deleted.)
+- **No tests for `index.ts` at all** — CORS, session initialize/lookup/delete, the cleanup interval, the multi-session bug, the `mcp-session-id` header. Given that's where the actual risk lives, a `supertest`-based integration test would pay for itself in a few hours.
+
+### 🟡 Smells
+
+- L1–12 — Manual `chalk` mock with `__esModule` shim. Side-effect of `chalk` only being needed for the dead `formatThought` function. Drops out for free if `formatThought` is removed.
+- L34–36 — `if (result.isError) console.log(...)` debug helper left in test code.
+
+---
+
+## `web/index.html` (436 lines, single-file SPA)
+
+### 🟠 Risks
+
+- **L179 — Hardcoded `http://127.0.0.1:3000/mcp`.** Breaks when `PORT` is overridden or when accessed via a different hostname (e.g. through Docker on `host.docker.internal`). Use `window.location.origin + '/mcp'`.
+- **L277 — `EventSource` URL hardcoded similarly.**
+- **L186 — Reads `mcp-session-id` from response headers** — works only because the page is same-origin. If `Access-Control-Expose-Headers` is added on the server, this stays correct cross-origin too.
+
+### 🟡 Smells
+
+- **No CSP, no SRI.** Inline `<script>` is the only resource so it's low-risk, but a basic `Content-Security-Policy` meta would harden it.
+- L294–300 — `eventSource.onerror` re-enables "Start Stream" but doesn't update `setStatus`; UI can show "Connected" while the stream is actually closed.
+- L417 — `setTimeout(resolve, 1000)` between `listTools()` and `testSequentialThinking()` is a fixed sleep papering over an unobserved race. Either chain on the actual response, or drop it.
+
+---
+
+## Build & tooling
+
+### `package.json`
+
+- **🟡 `prepare` runs `npm run build` on every install.** Fine for git installs (it's the workaround for `dist/` being gitignored), painful if a downstream tries `npm i --ignore-scripts`. Acceptable; document in README.
+- **🔵 `bin` → `dist/index.js`,** but `dist/` is in `.gitignore` (line 2 of `.gitignore`) and not tracked. Anyone cloning + `npm link` works because of `prepare`. OK.
+- **🟡 `version: 0.6.2` in `package.json` vs `version: "0.2.0"` reported by the running server** (`index.ts:185`). Either drive both from the same source (`pkg.version`) or update the server constant on each release.
+
+### `tsconfig.json`
+
+- **🟠 `strict: false` + `noImplicitAny: false`.** Disables the strongest TS guarantees. The bugs above (silent casts of optional fields, the `transport as unknown as ...` cast) would have been flagged by `strict: true`. Recommended fix.
+- **🔵 `exclude: ["**/*.test.ts"]`** is fine for the production build; tests are compiled by `ts-jest` separately.
+
+### `jest.config.mjs`
+
+- **🟡 No coverage threshold** despite the `test:coverage` script. Easy win — set 80%+ on the `src/` directory.
+- **🔵 The chalk transform allow-list is only needed for the dead `formatThought` path**; removing it removes one ESM source of grief in tests.
+
+### `Dockerfile`
+
+- **🟠 L36 — `COPY --from=builder /app/node_modules ./node_modules`** brings devDependencies into the runtime image (jest, ts-jest, types/*, typescript, shx). Add a `npm ci --omit=dev` stage (or `npm prune --omit=dev` after build) to slim the image substantially.
+- **🟡 L51 — `ENV DOCKER=true`** is the env-as-config seam noted earlier; keep but rename to `HOST=0.0.0.0` in app code.
+- **🔵 L40–47 — Non-root user, multi-stage build, pinned base by digest, `HEALTHCHECK` using built-in `fetch`.** All good.
+
+### CI (`.github/`)
+
+- **🟡 `actions/tests/action.yml:8` — `actions/setup-node@v4` not pinned to a SHA**, while every other action in the repo is. Inconsistent and undermines the supply-chain hygiene Renovate provides via `pinDigests`.
+- **🟡 No security workflows.** No CodeQL, no Trivy/Grype on the published image, no `npm audit` step. With Renovate updating deps you'll catch *known* CVEs in deps, but not vulnerabilities in the image's OS layer or your own code patterns.
+- **🟡 `on-push-main.yml` and `on-release.yml` both build & push images.** No mutual exclusion: if a tag is pushed on a commit that also lands on `main`, two pipelines race. Consider gating one on the other.
+- **🔵 `renovate.json` is well-configured** (semantic commits, pin digests, npm dedupe, node version constraint on `@types/node < 23`).
+
+### Misc
+
+- **`README.md` JSON example (L74–80)** has a trailing comma — invalid JSON.
+- README does not mention `ALLOWED_ORIGINS`, `NODE_ENV`, or `DOCKER` env vars; only `PORT` is documented.
+- `.gitignore` includes `.claude` — fine for excluding agent-managed state, but coexists with the branch name `claude/codebase-review-OnQKR`.
+
+---
+
+## Additional findings (second-pass verification)
+
+These were caught during a verification pass against the source and are adjacent to or extending the items above.
+
+### Nuances on existing findings
+
+- **L25 / L28 `!data.thoughtNumber` / `!data.totalThoughts` for `0`** — partly defended by the JSON Schema (`minimum: 1` in `index.ts`), so `0` is rejected upstream regardless. The bug is primarily a misleading *error message* ("must be a number" when `0` is a number), not a reachable functional hole. The empty-string `thought` case at L22 *is* reachable: the schema has no `minLength` on `thought`.
+- **L153 dev-wildcard CORS** — `NODE_ENV` is never explicitly set in dev paths in this repo (only `Dockerfile:50` sets it to `production`). The risk surface is narrower than it reads; it triggers only if a user sets `NODE_ENV=development` themselves. Tightening to `host === '127.0.0.1'` is still the right fix.
+
+### Additional findings not in the original review
+
+- **🟠 Transports are not force-closed on shutdown.** Even if the recommended SIGTERM/SIGINT handler is added, it must iterate the `transports` map and call `.close()` on each — otherwise in-flight SSE streams just dangle until Docker's grace period expires. (`index.ts:176`, `index.ts:315–338`.)
+- **🟡 Cleanup loop mutates the object it iterates.** `for (const sessionId in sessionStates)` at `index.ts:323` runs `transport.close()` which synchronously triggers the `onclose` handler that `delete`s the key from `sessionStates` (L257). JS defines this case but it is fragile; snapshot with `Object.keys(sessionStates)` first. Adjacent to the existing L318 finding, but a distinct mechanism.
+- **🟡 `web/index.html:186` reads `mcp-session-id` from a `fetch` response.** The original review notes the missing `Access-Control-Expose-Headers`. Additionally, if anyone later fronts this with auth cookies and `credentials: 'include'`, the absence of `Vary: Origin` on the response can cache-poison via shared intermediaries. Worth adding `Vary: Origin` alongside any CORS response that varies by origin.
+- **🔵 The L181/263 "single-Server, many-transports" finding is the highest-leverage item to verify first.** Until the SDK semantics for `server.connect(transport)` called repeatedly on one `Server` are confirmed for `@modelcontextprotocol/sdk ^1.22.0`, every other fix is built on uncertain ground. Recommend a `supertest` integration test that initializes two sessions and asserts `tools/call` is routed to the correct per-session `SequentialThinkingServer` (verified by `thoughtHistoryLength`).
+
+---
+
+## Top-priority fix list
+
+If you only do a handful of things:
+
+1. Delete the dead `formatThought` call/method (and the chalk dependency + jest mock that exists only to support it). `src/SequentialThinkingServer.ts:48–74,93`.
+2. Remove unused imports `InitializeRequestSchema` and `ThoughtData` in `index.ts:9,17`.
+3. Audit the single-`Server`-many-transports pattern in `index.ts:181,263` against the SDK; this is the most likely *runtime* bug.
+4. Fix the falsy-guard validation messages in `SequentialThinkingServer.ts:22,25,28` and add type checks for the optional fields at L40–44.
+5. Trim `node_modules` in the Docker release stage (`Dockerfile:36`).
+6. Cap `thoughtHistory` size or document trust boundaries; add a SIGTERM handler that clears the interval and closes transports.
+7. Bump `tsconfig` to `strict: true` and pin `actions/setup-node` to a SHA.
+8. Sync `version` between `package.json` and the MCP `Server` constructor — derive both from `package.json`.
+
+The core thinking loop is small, readable, and well-tested for its happy paths; the rough edges are concentrated in the HTTP/session/build seams around it.
+
+---
+
+## Upstream comparison — `modelcontextprotocol/servers/src/sequentialthinking`
+
+Compared against upstream `main` (cloned to `/tmp/upstream-mcp/servers`). Upstream layout: `index.ts` (transport + tool registration via Zod), `lib.ts` (the `SequentialThinkingServer` class), `__tests__/lib.test.ts` (vitest). Both upstream and this fork report `package.json` version `0.6.2` and `Server` constructor version `0.2.0`.
+
+### Verdict
+
+**The core sequential-thinking algorithm is upstream-identical.** History tracking, branch recording, auto-bump of `totalThoughts`, JSON response shape, error shape, and the `formatThought` border/header rendering match byte-for-byte. All drift sits in three layers *wrapped around* the algorithm: validation, logging, and transport.
+
+### What's identical to upstream
+
+- `ThoughtData` interface — exact match.
+- `formatThought()` body — exact match (same chalk colors, same border math, same emoji, same width bug).
+- `processThought()` core flow:
+  - Auto-bump rule `if (thoughtNumber > totalThoughts) totalThoughts = thoughtNumber`.
+  - `thoughtHistory.push(...)`.
+  - Branch guard `if (branchFromThought && branchId)` — the silent-drop smell at `SequentialThinkingServer.ts:86–91` exists upstream too (this fork inherited it, did not introduce it).
+  - Success-response JSON shape: `{thoughtNumber, totalThoughts, nextThoughtNeeded, branches, thoughtHistoryLength}`.
+  - Error-response shape: `{error, status: 'failed'}` with `isError: true`.
+- Tool description text (the long `description` field on `SEQUENTIAL_THINKING_TOOL`) — same content, same numbered guidance.
+- Tool `required` fields — `["thought", "nextThoughtNeeded", "thoughtNumber", "totalThoughts"]`.
+- Field set, types, and `minimum: 1` on numeric fields.
+- The `0.6.2` (package) vs `0.2.0` (server constructor) version mismatch — **upstream has the same drift**, so this is an inherited bug, not a fork-introduced one.
+
+### What this fork drifted from upstream
+
+#### 1. Validation (reimplemented, slightly wrong)
+
+- **Upstream:** no validation in `lib.ts`; Zod at the tool registration layer in `index.ts` does it, including `z.coerce` for numbers/booleans and a custom `coercedBoolean` preprocess that correctly handles the string `"false"` (a known LLM pitfall).
+- **This fork:** hand-rolled `validateThoughtData()` in `SequentialThinkingServer.ts` with the falsy-guard bugs already flagged at L22/25/28 (`!data.thought` rejects `""`, `!data.thoughtNumber` rejects `0`, etc.). Optional fields are `as`-cast without `typeof` checks.
+- **Reframing of the existing finding:** these aren't gratuitous bugs — they're a reimplementation of what upstream gets for free from Zod, executed less robustly. **The cleanest fix is to adopt Zod here too** (already a transitive dep via the MCP SDK) and delete `validateThoughtData`. Bonus: client-sent `"5"` and `"true"` strings would start working.
+
+#### 2. Logging (regression: feature deleted, cost retained)
+
+- **Upstream:** `lib.ts` exposes `DISABLE_THOUGHT_LOGGING` env var. When unset, `console.error(formattedThought)` runs every call. The formatted box is the *intended runtime output* of the tool.
+- **This fork:** `formatThought()` is invoked at `SequentialThinkingServer.ts:93` and the result discarded. No env var, no `console.error`.
+- **Reframing of the L93 "dead code" finding:** this is **a deletion of upstream's intentional log line**, almost certainly to satisfy the README's "Privacy by Design — no sensitive tool inputs/outputs are logged" claim. But the `formatThought()` call (and its chalk dep, and the jest ESM mock that exists only for it) was left behind. Two clean fixes:
+  - **Match upstream:** restore `console.error(formattedThought)` and gate it on `DISABLE_THOUGHT_LOGGING` (default-on or default-off — pick one and document).
+  - **Honor the privacy claim:** delete `formatThought`, the chalk dep, and the jest chalk mock. Drops ESM-test friction for free.
+
+#### 3. Tool registration (missing upstream features)
+
+Upstream's `index.ts` registers the tool with three things this fork doesn't surface:
+
+- **`outputSchema`** declaring the response shape (`thoughtNumber`, `totalThoughts`, `nextThoughtNeeded`, `branches: string[]`, `thoughtHistoryLength`).
+- **`annotations`** — `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`, `openWorldHint: false`. MCP hosts use these for caching, retry policy, and UI.
+- **`structuredContent`** alongside `content` in the response — upstream parses its own JSON text and returns it as a structured object so hosts don't have to re-parse.
+
+This fork uses the lower-level `Server` + raw JSON Schema approach; upstream uses `McpServer.registerTool()` which makes these declarative. **Hosts of this fork get a degraded tool experience** (no structured output, no idempotency hint).
+
+#### 4. SDK version
+
+- **Upstream:** `@modelcontextprotocol/sdk: ^1.26.0`.
+- **This fork:** `@modelcontextprotocol/sdk: ^1.22.0`.
+
+Four minors behind. Worth a Renovate sweep to confirm no SDK behaviors this fork relies on have changed (especially the multi-transport question raised in the `index.ts` review).
+
+#### 5. Transport / session model (additive — the fork's purpose)
+
+- **Upstream:** stdio, single in-process `SequentialThinkingServer`, one user, no sessions, lives for the process lifetime. Global `thoughtHistory` and `branches`.
+- **This fork:** Streamable HTTP, multi-session, per-`mcp-session-id` `SequentialThinkingServer`, 1-hour idle cleanup. Per-session `thoughtHistory` and `branches` (correct for an HTTP service).
+
+This is the fork's reason-for-existence. It does not change the thinking algorithm; it scopes the algorithm's state per session.
+
+### Test-coverage delta vs upstream
+
+Upstream has 15 tests (vitest); this fork has 9 (jest). Differences:
+
+| Test area | Upstream | This fork |
+|---|---|---|
+| Validation errors | — (Zod handles it one layer up) | ✅ 4 tests |
+| Multiple thoughts in same branch | ✅ | — |
+| Very long thought string (10 000 chars) | ✅ | — |
+| `thoughtNumber=1, totalThoughts=1` edge case | ✅ | — |
+| Response-structure assertions | ✅ | partial |
+| Logging-enabled vs disabled paths | ✅ | — (no logging path exists) |
+| Auto-bump of `totalThoughts` | ✅ | ✅ |
+| Branch tracking | ✅ | ✅ |
+| Revision thoughts | partial (covered via optional fields test) | ✅ |
+
+If the validation drift above is fixed by adopting Zod, the local validation-error tests become moot; porting upstream's coverage tests across (long string, single-thought, multi-thought-same-branch) would close the remaining gap.
+
+### Recommended actions from this comparison
+
+1. **Decide on logging:** match upstream (`DISABLE_THOUGHT_LOGGING` gate) or delete `formatThought` + chalk + the jest chalk mock. Don't keep the current half-state.
+2. **Adopt Zod in `index.ts`** for tool input validation; delete `validateThoughtData` from `SequentialThinkingServer.ts`. Resolves the L22/25/28 falsy-guard bugs and the L40–44 unchecked optionals in one stroke.
+3. **Migrate from `Server` to `McpServer.registerTool()`** so `outputSchema`, `annotations`, and `structuredContent` come along for the ride. Keep the StreamableHTTP transport — that part is orthogonal.
+4. **Bump `@modelcontextprotocol/sdk` to `^1.26.0`** and re-verify the multi-transport question (`index.ts:181/263`) against the new version.
+5. **Port upstream's edge-case tests** (long string, `1/1`, multi-thought-same-branch) into the local jest suite.
+6. **Sync the `0.2.0` constructor version** with `package.json` — and consider upstreaming the same fix, since they share the bug.

--- a/internal/thinking/schema_test.go
+++ b/internal/thinking/schema_test.go
@@ -2,6 +2,7 @@ package thinking
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -109,7 +110,7 @@ func TestValidateRequiredFields(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
 			}
-			if !contains(err.Error(), tc.wantErr) {
+			if !strings.Contains(err.Error(), tc.wantErr) {
 				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantErr)
 			}
 		})
@@ -129,21 +130,6 @@ func TestValidateAcceptsEmptyAssumptions(t *testing.T) {
 	if err := td.Validate(); err != nil {
 		t.Fatalf("empty assumptions should be allowed, got: %v", err)
 	}
-}
-
-// contains is a tiny strings.Contains wrapper for table tests; implemented in
-// schema_test.go to keep production code free of test-only helpers.
-func contains(s, substr string) bool {
-	return len(substr) == 0 || (len(s) >= len(substr) && stringIndex(s, substr) >= 0)
-}
-
-func stringIndex(s, substr string) int {
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-	return -1
 }
 
 func TestValidateConfidenceRange(t *testing.T) {
@@ -179,7 +165,7 @@ func TestValidateConditionalNextStepRationale(t *testing.T) {
 		td.NextThoughtNeeded = boolPtr(true)
 		td.NextStepRationale = ""
 		err := td.Validate()
-		if err == nil || !contains(err.Error(), "nextStepRationale required") {
+		if err == nil || !strings.Contains(err.Error(), "nextStepRationale required") {
 			t.Errorf("expected nextStepRationale error, got %v", err)
 		}
 	})
@@ -215,7 +201,7 @@ func TestValidateBranchBothOrNeither(t *testing.T) {
 		td.BranchFromThought = intPtr(1)
 		td.BranchID = ""
 		err := td.Validate()
-		if err == nil || !contains(err.Error(), "branchFromThought and branchId") {
+		if err == nil || !strings.Contains(err.Error(), "branchFromThought and branchId") {
 			t.Errorf("expected both-or-neither error, got %v", err)
 		}
 	})
@@ -224,7 +210,7 @@ func TestValidateBranchBothOrNeither(t *testing.T) {
 		td.BranchFromThought = nil
 		td.BranchID = "branch-a"
 		err := td.Validate()
-		if err == nil || !contains(err.Error(), "branchFromThought and branchId") {
+		if err == nil || !strings.Contains(err.Error(), "branchFromThought and branchId") {
 			t.Errorf("expected both-or-neither error, got %v", err)
 		}
 	})

--- a/internal/thinking/server.go
+++ b/internal/thinking/server.go
@@ -3,7 +3,7 @@ package thinking
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -257,7 +257,7 @@ func sortedKeys(m map[string][]ThoughtData) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	return keys
 }
 

--- a/internal/thinking/server_test.go
+++ b/internal/thinking/server_test.go
@@ -3,7 +3,7 @@ package thinking
 import (
 	"encoding/json"
 	"math"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -155,7 +155,7 @@ func TestProcessThoughtRecordsBranch(t *testing.T) {
 
 	var resp ThoughtResponse
 	_ = json.Unmarshal([]byte(res.StructuredJSON), &resp)
-	sort.Strings(resp.Branches)
+	slices.Sort(resp.Branches)
 	if len(resp.Branches) != 1 || resp.Branches[0] != "branch-a" {
 		t.Errorf("Branches = %v, want [branch-a]", resp.Branches)
 	}

--- a/internal/thinking/server_test.go
+++ b/internal/thinking/server_test.go
@@ -109,7 +109,7 @@ func TestProcessThoughtRevisesOutOfRange(t *testing.T) {
 	if !res.IsError {
 		t.Error("expected IsError for out-of-range revisesThought")
 	}
-	if !contains(res.Text, "revisesThought 99 out of range") {
+	if !strings.Contains(res.Text, "revisesThought 99 out of range") {
 		t.Errorf("error message: %s", res.Text)
 	}
 	if got := s.HistoryLength(); got != 1 {
@@ -176,7 +176,7 @@ func TestProcessThoughtRevisionRangeCheck(t *testing.T) {
 	if !res.IsError {
 		t.Error("expected IsError for out-of-range revisesThought")
 	}
-	if !contains(res.Text, "revisesThought 5 out of range") {
+	if !strings.Contains(res.Text, "revisesThought 5 out of range") {
 		t.Errorf("error message: %s", res.Text)
 	}
 }
@@ -320,20 +320,18 @@ func TestProcessThoughtConcurrent(t *testing.T) {
 	const goroutines = 100
 	const perGoroutine = 10
 	var wg sync.WaitGroup
-	wg.Add(goroutines)
 
-	for g := 0; g < goroutines; g++ {
-		go func(gID int) {
-			defer wg.Done()
-			for i := 0; i < perGoroutine; i++ {
-				td := validInput(gID*perGoroutine + i + 1)
+	for g := range goroutines {
+		wg.Go(func() {
+			for i := range perGoroutine {
+				td := validInput(g*perGoroutine + i + 1)
 				td.TotalThoughts = goroutines * perGoroutine
 				if _, err := s.ProcessThought(td); err != nil {
-					t.Errorf("goroutine %d iter %d: %v", gID, i, err)
+					t.Errorf("goroutine %d iter %d: %v", g, i, err)
 					return
 				}
 			}
-		}(g)
+		})
 	}
 	wg.Wait()
 

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+vars:
+  BINARY: critical-thinking
+  PKG: ./cmd/critical-thinking
+  VERSION:
+    sh: git describe --tags --always --dirty
+  COMMIT:
+    sh: git rev-parse --short HEAD
+  DATE:
+    sh: date -u +%Y-%m-%dT%H:%M:%SZ
+  LDFLAGS: -s -w -X main.version={{.VERSION}} -X main.commit={{.COMMIT}} -X main.date={{.DATE}}
+
+tasks:
+  build:
+    cmds:
+      - CGO_ENABLED=0 go build -trimpath -ldflags "{{.LDFLAGS}}" -o bin/{{.BINARY}} {{.PKG}}
+  test:
+    cmds:
+      - go test ./...
+  test-race:
+    cmds:
+      - go test -race -coverprofile=coverage.txt ./...
+  vet:
+    cmds:
+      - go vet ./...
+  lint:
+    cmds:
+      - golangci-lint run ./...
+  clean:
+    cmds:
+      - rm -rf bin/ coverage.txt


### PR DESCRIPTION
## Summary

**Phase 0** of the multi-phase standards refactor for `critical-thinking`: bring the repo onto the project's Go standards bundle (build tooling, linting, vuln scanning, modern-Go idioms) with **zero behavior change** to the binary. Later phases (Cobra, slog, Viper, docs/examples) follow separately.

### What changed
- **Build tool:** new `taskfile.yml` (`build`/`test`/`test-race`/`vet`/`lint`/`clean`) with full `-ldflags` injection of `version`/`commit`/`date`; `commit`/`date` package vars added in `main.go`.
- **Linting:** new `.golangci.yml` (v2: govet, errcheck, staticcheck, gosec, unused, gocritic); all findings resolved — `golangci-lint run ./...` is clean. Two `//nolint` directives, each with a justifying comment (commit/date unused until the Phase 1 `version` subcommand; `exitAfterDefer` on the `ListenAndServe` fatal path).
- **CI:** `.github/actions/tests/action.yml` now installs Task and runs `task vet` / `task test-race` / `task build`, plus `golangci-lint-action` and `govulncheck`.
- **Release builds:** `Dockerfile` and `.goreleaser.yaml` now inject `commit`/`date` (alongside the existing `version`).
- **Modern-Go idioms:** `slices.Sort` (was `sort.Strings`) and `slices.Contains` (replacing a hand-rolled `contains` helper) in production; in tests, hand-rolled `contains`/`stringIndex` helpers replaced by `strings.Contains`, `wg.Go`, and range-over-int.
- **Cleanups:** removed an empty `pkg/config/` dir and a stale `docker-bake.hcl` reference in `docs/development.md`; archived the predecessor-TypeScript `codebase-review.md` to `docs/history/`.

### Notes
- **Zero behavior change** — verified: `schema` and `-cli` output unchanged; only build/tooling and behavior-identical idiom swaps. An independent comprehensive review of the full diff found **no Critical/Important issues**.
- Deferred to Phase 1 (where these exact lines are revisited): normalize the one legacy-spaced `// nolint:gocritic` directive, and drop the `//nolint:unused` on `commit`/`date` once the `version` subcommand consumes them. (The `//nolint:gocritic` placement is position-sensitive — re-run the linter after any move.)

## Test Plan
- [x] `task vet` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./...` — all pass
- [x] `gofmt -l .` — clean
- [x] `govulncheck ./...` — no vulnerabilities affecting this code
- [x] `goreleaser check` — config valid
- [x] `task build` + `schema`/`-cli` smoke — unchanged output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
