### PR TITLE
chore: gitignore the critical-thinking binary and bin/ build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries
-/rubber-ducky-mcp
+/critical-thinking
+/bin/
 *.exe
 *.test
 *.out


### PR DESCRIPTION
## Summary

Fixes a stale `.gitignore`: it still listed the old binary name `/rubber-ducky-mcp` and did not ignore the artifacts the current build tooling produces, leaving them as untracked files.

- Replaces `/rubber-ducky-mcp` (dead — predates the `critical-thinking` rename) with `/critical-thinking` (the binary from `go build ./cmd/critical-thinking`).
- Adds `/bin/` (the `task build` output directory).

Now `go build`/`task build` output can't be accidentally committed.

## Test plan

- [x] `git check-ignore critical-thinking bin/ bin/critical-thinking` — all three ignored
- [x] `git status` — previously-untracked `bin/` and `critical-thinking` no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)