### PR TITLE
ci: build golangci-lint from source to match the go 1.26 target

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -32,9 +32,14 @@ runs:
       run: task vet
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v6
-      with:
-        version: latest
+      shell: bash
+      # Build golangci-lint from source with this job's Go toolchain. The
+      # marketplace action installs a prebuilt binary built with an older Go,
+      # and golangci-lint v2 refuses to run when its build-Go is lower than the
+      # go.mod target (go 1.26.3): "the Go language version used to build
+      # golangci-lint is lower than the targeted Go version". `go run` rebuilds
+      # it with the runner's Go, matching the govulncheck step below.
+      run: go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...
 
     - name: govulncheck
       shell: bash


### PR DESCRIPTION
## Problem

CI's lint step fails on every PR (and would on `main`):

```
Error: can't load config: the Go language version (go1.24) used to build
golangci-lint is lower than the targeted Go version (1.26.3)
##[error]golangci-lint exit with code 3
```

`golangci/golangci-lint-action@v6` with `version: latest` installs a **prebuilt** golangci-lint binary built with **go1.24**. golangci-lint v2 hard-refuses to run when its build-Go is lower than the module's `go.mod` target (`go 1.26.3`). No golangci-lint *release* is built with Go 1.26 yet, so pinning a version can't fix it — the linter must be **built with the runner's Go 1.26**.

This is unrelated to any code change — it fails identically on a docs/gitignore-only branch.

## Fix

Replace the action step with a `go run` that builds golangci-lint v2 from source using the job's Go toolchain (the runner already sets up Go 1.26), mirroring the existing `govulncheck` step in the same composite action.

## Verified locally (Go 1.26.3)

- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run ./...` → builds **v2.12.2 with go1.26.3**, exits 0, **0 issues** — no version-mismatch error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)