### PR TITLE
docs: correct the migration log heading from v2.0.0 to v1.6.0

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,13 +2,13 @@
 
 Cumulative breaking-change log for `critical-thinking`. Most recent changes first.
 
-## v2.0.0 — Flag CLI replaced by Cobra subcommands
+## v1.6.0 — Flag CLI replaced by Cobra subcommands
 
 The invocation surface moved from flags to subcommands. Every capability is unchanged —
 only how you invoke it changed. Bare `critical-thinking` now prints help (it no longer
 starts stdio automatically); use `critical-thinking serve`.
 
-| v1.x | v2.0.0 |
+| v1.x | v1.6.0 |
 |---|---|
 | `critical-thinking` (bare → stdio) | `critical-thinking serve` |
 | `critical-thinking -http :3000` | `critical-thinking serve --http :3000` |


### PR DESCRIPTION
## Summary

The Cobra-subcommand breaking change released as **v1.6.0** — the repo's `.releaserc.json` maps breaking changes to a minor bump (`{ "breaking": true, "release": "minor" }`). This aligns `docs/migration.md`'s section heading and version column with the actual release tag.

`README.md` and `docs/clients.md` docker tags were already set to `:v1.6.0` by the release pipeline's `bump-docker-tags` step; only `docs/migration.md` (outside that scope) still referenced v2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)