### PR TITLE
feat: route logging through log/slog to stderr; add --verbose/--log-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ critical-thinking schema          # prints the tool contract (description + JSON
 
 See [docs/clients.md#cli-no-mcp-host](docs/clients.md#cli-no-mcp-host) for CLI usage details and error-handling behaviour.
 
+Logs go to stderr. `--verbose` raises the level to debug (and traces JSON-RPC frames in stdio mode) and `--log-format=text|json` selects the format. See [docs/configuration.md#logging](docs/configuration.md#logging).
+
 ## One-call example
 
 Request:

--- a/cmd/critical-thinking/logging.go
+++ b/cmd/critical-thinking/logging.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+)
+
+// newLogger builds an slog.Logger writing to w at the given level. format selects
+// the handler: "text" (human-readable) or "json" (structured). Any other value
+// is an error — the {text,json} contract lives here and nowhere else. In
+// production w is always os.Stderr (set by the root PersistentPreRunE); stdout is
+// reserved for the JSON-RPC protocol and command output.
+func newLogger(w io.Writer, level slog.Level, format string) (*slog.Logger, error) {
+	opts := &slog.HandlerOptions{Level: level}
+	var h slog.Handler
+	switch format {
+	case "text":
+		h = slog.NewTextHandler(w, opts)
+	case "json":
+		h = slog.NewJSONHandler(w, opts)
+	default:
+		return nil, fmt.Errorf("invalid --log-format %q (want text|json)", format)
+	}
+	return slog.New(h), nil
+}

--- a/cmd/critical-thinking/logging_test.go
+++ b/cmd/critical-thinking/logging_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewLoggerFormats(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		wantErr   bool
+		checkJSON bool
+	}{
+		{name: "text", format: "text"},
+		{name: "json", format: "json", checkJSON: true},
+		{name: "unknown", format: "yaml", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger, err := newLogger(&buf, slog.LevelInfo, tt.format)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("newLogger(%q) err = nil, want error", tt.format)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("newLogger(%q) err = %v", tt.format, err)
+			}
+			logger.Info("hello", "k", "v")
+			out := buf.String()
+			if !strings.Contains(out, "hello") {
+				t.Errorf("output missing message; got %q", out)
+			}
+			if tt.checkJSON {
+				var m map[string]any
+				if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &m); err != nil {
+					t.Errorf("json format should emit valid JSON; got %q (err %v)", out, err)
+				}
+			}
+		})
+	}
+}
+
+func TestNewLoggerLevelGating(t *testing.T) {
+	var buf bytes.Buffer
+	logger, err := newLogger(&buf, slog.LevelInfo, "text")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger.Debug("should-not-appear")
+	if buf.Len() != 0 {
+		t.Errorf("Debug record must be suppressed at Info level; got %q", buf.String())
+	}
+
+	buf.Reset()
+	dbg, err := newLogger(&buf, slog.LevelDebug, "text")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbg.Debug("should-appear")
+	if !strings.Contains(buf.String(), "should-appear") {
+		t.Errorf("Debug record must appear at Debug level; got %q", buf.String())
+	}
+}

--- a/cmd/critical-thinking/mcpserver.go
+++ b/cmd/critical-thinking/mcpserver.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -25,15 +26,20 @@ const (
 
 // runStdio runs the server with one global SequentialThinkingServer instance.
 // One process = one session, no cross-stream risk by definition.
-func runStdio() {
+func runStdio() error {
 	state := thinking.NewServer()
 	srv := newMCPServer(state)
 
-	transport := &mcp.LoggingTransport{Transport: &mcp.StdioTransport{}, Writer: os.Stderr}
-	if err := srv.Run(context.Background(), transport); err != nil {
-		log.Printf("server failed: %v", err)
-		os.Exit(1)
+	var transport mcp.Transport = &mcp.StdioTransport{}
+	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		// --verbose: trace every JSON-RPC frame to stderr (stdout is the protocol).
+		transport = &mcp.LoggingTransport{Transport: transport, Writer: os.Stderr}
 	}
+
+	if err := srv.Run(context.Background(), transport); err != nil {
+		return fmt.Errorf("server failed: %w", err)
+	}
+	return nil
 }
 
 // runHTTP starts a Streamable HTTP server. Each session gets its own
@@ -50,16 +56,15 @@ func runStdio() {
 // The registry is NOT synchronized with the SDK's view of live sessions — once
 // the SDK closes a session we have no callback, so the count drifts upward.
 // /health exposes it as `sessionsCreated` to make the semantics explicit.
-func runHTTP(addr string) {
+func runHTTP(addr string) error {
 	// Wire ALLOWED_ORIGINS into the SDK's CSRF protection so browser clients
 	// from those origins aren't rejected by the SDK's default same-origin
 	// policy. Non-browser callers (no Origin / no Sec-Fetch-Site) are still
-	// allowed regardless. Built before the signal context's defer stop() is
-	// registered so a fatal config error here can't skip a pending defer.
+	// allowed regardless.
 	csrf := http.NewCrossOriginProtection()
 	for _, o := range parseAllowedOrigins(os.Getenv("ALLOWED_ORIGINS")) {
 		if err := csrf.AddTrustedOrigin(o); err != nil {
-			log.Fatalf("invalid ALLOWED_ORIGINS entry %q: %v", o, err)
+			return fmt.Errorf("invalid ALLOWED_ORIGINS entry %q: %w", o, err)
 		}
 	}
 
@@ -71,6 +76,7 @@ func runHTTP(addr string) {
 	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		state := thinking.NewServer()
 		registry.add(state)
+		slog.Debug("http session created", "sessionsCreated", registry.count())
 		return newMCPServer(state)
 	}, &mcp.StreamableHTTPOptions{
 		SessionTimeout:        idleTimeout,
@@ -99,17 +105,15 @@ func runHTTP(addr string) {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
 		defer cancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {
-			log.Printf("shutdown: %v", err)
+			slog.Error("graceful shutdown failed", "err", err)
 		}
 	}()
 
-	log.Printf("critical-thinking %s listening on http://%s", version, listenAddr)
+	slog.Info("listening", "url", "http://"+listenAddr, "version", version)
 	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		//nolint:gocritic // defer stop() only unregisters signal handlers and is
-		// moot at process exit; the alternatives (return / os.Exit) would change the
-		// non-zero exit code or require refactoring runHTTP's signature.
-		log.Fatalf("listen: %v", err)
+		return fmt.Errorf("listen: %w", err)
 	}
+	return nil
 }
 
 // newMCPServer constructs a configured *mcp.Server with the criticalthinking

--- a/cmd/critical-thinking/root.go
+++ b/cmd/critical-thinking/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log/slog"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -39,6 +40,28 @@ func newRootCmd() *cobra.Command {
 	// Default I/O to the process streams; tests override via SetOut/SetErr.
 	root.SetOut(os.Stdout)
 	root.SetErr(os.Stderr)
+
+	// Phase 2 (D6): root persistent flags wired to slog. --verbose lowers the
+	// level to Debug (and enables the stdio JSON-RPC frame trace, see runStdio);
+	// --log-format selects the handler. The {text,json} contract lives in
+	// newLogger, which returns an error on any other value.
+	var verbose bool
+	var logFormat string
+	root.PersistentFlags().BoolVar(&verbose, "verbose", false, "enable debug logging (and stdio JSON-RPC frame tracing)")
+	root.PersistentFlags().StringVar(&logFormat, "log-format", "text", "log output format: text|json")
+
+	root.PersistentPreRunE = func(_ *cobra.Command, _ []string) error {
+		level := slog.LevelInfo
+		if verbose {
+			level = slog.LevelDebug
+		}
+		logger, err := newLogger(os.Stderr, level, logFormat) // newLogger validates logFormat
+		if err != nil {
+			return err // SilenceErrors=false → cobra prints to stderr; never stdout
+		}
+		slog.SetDefault(logger)
+		return nil
+	}
 
 	root.AddCommand(
 		newServeCmd().Command,

--- a/cmd/critical-thinking/root_test.go
+++ b/cmd/critical-thinking/root_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"log/slog"
 	"strings"
 	"testing"
 )
@@ -89,5 +91,45 @@ func TestRootUnknownCommandWritesStderrNotStdout(t *testing.T) {
 	}
 	if !strings.Contains(errBuf.String(), "unknown command") {
 		t.Errorf("stderr should describe the unknown command; got: %q", errBuf.String())
+	}
+}
+
+// TestRootInvalidLogFormatKeepsStdoutClean: a bad --log-format fails closed via
+// newLogger before any subcommand runs, on stderr only (stdout stays clean).
+func TestRootInvalidLogFormatKeepsStdoutClean(t *testing.T) {
+	cmd := newRootCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--log-format", "yaml", "version"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("invalid --log-format should return an error")
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must stay clean on invalid --log-format; got %q", out.String())
+	}
+	if !strings.Contains(errBuf.String(), "want text|json") {
+		t.Errorf("stderr should carry newLogger's validation message; got %q", errBuf.String())
+	}
+}
+
+// TestRootVerboseEnablesDebug: --verbose makes PersistentPreRunE install a
+// Debug-level default logger before the (runnable) subcommand executes.
+func TestRootVerboseEnablesDebug(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cmd := newRootCmd()
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--verbose", "version"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	if !slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		t.Error("--verbose should set the default logger to Debug level")
 	}
 }

--- a/cmd/critical-thinking/serve.go
+++ b/cmd/critical-thinking/serve.go
@@ -9,8 +9,8 @@ import (
 // default to the real runStdio/runHTTP.
 type serveCmd struct {
 	*cobra.Command
-	stdioRun func()
-	httpRun  func(addr string)
+	stdioRun func() error
+	httpRun  func(addr string) error
 }
 
 // newServeCmd builds the `serve` command. With no --http flag it runs the
@@ -31,11 +31,9 @@ func newServeCmd() *serveCmd {
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if httpAddr != "" {
-				c.httpRun(httpAddr)
-				return nil
+				return c.httpRun(httpAddr)
 			}
-			c.stdioRun()
-			return nil
+			return c.stdioRun()
 		},
 	}
 	c.Command.Flags().StringVar(&httpAddr, "http", "", `serve Streamable HTTP at this address (e.g. ":3000"); empty = stdio`)

--- a/cmd/critical-thinking/serve_test.go
+++ b/cmd/critical-thinking/serve_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -54,5 +57,41 @@ func TestServeRunEPropagatesError(t *testing.T) {
 	err := cmd.Execute()
 	if !errors.Is(err, wantErr) {
 		t.Errorf("serve RunE err = %v, want %v", err, wantErr)
+	}
+}
+
+// TestServeStdoutStaysCleanWhenLogging proves the load-bearing invariant: when
+// the serve run path logs via the default slog logger, the record goes to the
+// (stderr-bound) handler writer and NEVER to stdout. The stub re-points
+// slog.SetDefault at a buffer because running serveCmd standalone does not
+// invoke the root PersistentPreRunE.
+func TestServeStdoutStaysCleanWhenLogging(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	c := newServeCmd()
+	var logBuf bytes.Buffer
+	c.stdioRun = func() error {
+		logger, err := newLogger(&logBuf, slog.LevelInfo, "text")
+		if err != nil {
+			return err
+		}
+		slog.SetDefault(logger)
+		slog.Info("serve is logging")
+		return nil
+	}
+
+	var out, errBuf bytes.Buffer
+	c.SetOut(&out)
+	c.SetErr(&errBuf)
+	c.SetArgs([]string{})
+	if err := c.Execute(); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must stay clean while logging; got %q", out.String())
+	}
+	if !strings.Contains(logBuf.String(), "serve is logging") {
+		t.Errorf("log record should reach the stderr-side buffer; got %q", logBuf.String())
 	}
 }

--- a/cmd/critical-thinking/serve_test.go
+++ b/cmd/critical-thinking/serve_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -9,8 +10,8 @@ func TestServeCmdDefaultsToStdio(t *testing.T) {
 
 	var stdioCalled bool
 	var httpAddr string
-	cmd.stdioRun = func() { stdioCalled = true }
-	cmd.httpRun = func(addr string) { httpAddr = addr }
+	cmd.stdioRun = func() error { stdioCalled = true; return nil }
+	cmd.httpRun = func(addr string) error { httpAddr = addr; return nil }
 
 	cmd.SetArgs([]string{})
 	if err := cmd.Execute(); err != nil {
@@ -29,8 +30,8 @@ func TestServeCmdHTTPWhenFlagSet(t *testing.T) {
 
 	var stdioCalled bool
 	var httpAddr string
-	cmd.stdioRun = func() { stdioCalled = true }
-	cmd.httpRun = func(addr string) { httpAddr = addr }
+	cmd.stdioRun = func() error { stdioCalled = true; return nil }
+	cmd.httpRun = func(addr string) error { httpAddr = addr; return nil }
 
 	cmd.SetArgs([]string{"--http", ":3000"})
 	if err := cmd.Execute(); err != nil {
@@ -41,5 +42,17 @@ func TestServeCmdHTTPWhenFlagSet(t *testing.T) {
 	}
 	if httpAddr != ":3000" {
 		t.Errorf("httpRun addr = %q, want :3000", httpAddr)
+	}
+}
+
+func TestServeRunEPropagatesError(t *testing.T) {
+	cmd := newServeCmd()
+	wantErr := errors.New("boom")
+	cmd.stdioRun = func() error { return wantErr }
+	cmd.httpRun = func(string) error { return nil }
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if !errors.Is(err, wantErr) {
+		t.Errorf("serve RunE err = %v, want %v", err, wantErr)
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,6 +26,22 @@ critical-thinking serve --http :3000
 
 The HTTP server binds to `127.0.0.1` by default (or `0.0.0.0` when `DOCKER=true`). Each session gets its own `*mcp.Server` with its own `SequentialThinkingServer`, constructed inside a factory closure — there is no map keyed by session ID anywhere, by design. The closure scope is the cross-session isolation invariant.
 
+## Logging
+
+All logs go to **stderr** via `log/slog`. In stdio mode stdout is the JSON-RPC
+channel, and in `cli` / `schema` / `version` it carries command output — so nothing
+but protocol/output ever reaches stdout.
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--verbose` | off | Sets the log level to `Debug`. In stdio mode it also traces every JSON-RPC frame to stderr (off by default). |
+| `--log-format` | `text` | Handler format: `text` (human-readable) or `json` (structured). Any other value exits non-zero with an error on stderr. |
+
+Both are persistent root flags, so they work before or after any subcommand
+(`critical-thinking --verbose serve`, `critical-thinking serve --log-format=json`).
+The library engine (`internal/thinking`) emits no logs — it returns errors and lets
+the caller decide.
+
 ## HTTP endpoints
 
 | Path | Methods | Purpose |

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,16 @@
 
 Cumulative breaking-change log for `critical-thinking`. Most recent changes first.
 
+## v1.7.0 — Logging routed to stderr; `--verbose` / `--log-format`
+
+Non-breaking. Logging moved to `log/slog`, always on **stderr**. Two new persistent
+root flags: `--verbose` (debug level; also enables stdio JSON-RPC frame tracing) and
+`--log-format=text|json` (default `text`).
+
+**Behavior change:** stdio `serve` no longer traces every JSON-RPC frame to stderr by
+default — that trace is now opt-in via `--verbose`. stdout (the protocol channel) is
+unchanged. No engine, field, schema, or transport behavior changed.
+
 ## v1.6.0 — Flag CLI replaced by Cobra subcommands
 
 The invocation surface moved from flags to subcommands. Every capability is unchanged —


### PR DESCRIPTION
## Summary
- Migrate the binary's logging from stdlib `log` to `log/slog`, routed exclusively to **stderr** — in stdio `serve` mode stdout is the JSON-RPC channel and must stay clean.
- Add root persistent flags `--verbose` (debug level; also enables the stdio JSON-RPC frame trace) and `--log-format=text|json` (default `text`), wired via the root `PersistentPreRunE` → `slog.SetDefault`. A pure `newLogger` helper owns the `{text,json}` contract and errors on unknown formats.
- Refactor `runStdio()` / `runHTTP(addr)` to return `error` instead of `log.Fatalf`/`os.Exit` — drops the `//nolint:gocritic` exitAfterDefer suppression and lets `defer stop()` actually run on the listen-failure path (a real correctness fix).
- `internal/thinking` stays log-free. No new dependencies (`go.mod`/`go.sum` unchanged).

## Behavior change (non-breaking)
Default stdio `serve` no longer traces every JSON-RPC frame to stderr — that trace is now opt-in via `--verbose`. stdout is unchanged. Documented in `docs/migration.md` (v1.7.0 entry), `docs/configuration.md` (Logging section), and `README.md`.

> The 12-factor Go mapping prescribes logs → stdout; this server deliberately routes to **stderr** because stdout is the MCP JSON-RPC channel. The 12-factor spirit (event stream to a standard stream, no in-process files/rotation) is preserved; only the stream differs.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- [x] `go test -race ./...` — all pass. New tests: `newLogger` formats/level-gating/unknown-format-error; root invalid-`--log-format` (clean stdout) + `--verbose`-enables-debug; serve error-propagation + stdout-safety guard
- [x] `golangci-lint` (v2, from source, CI-matching) — 0 issues
- [x] Binary smoke: `--verbose`/`--log-format` listed on root + `serve`; `--log-format=bogus` → exit 1, empty stdout, error on stderr; `cli --json` pure NDJSON; stdio stdout log-free in both modes; `--verbose` gates the frame trace (default stderr 45B vs verbose 218B with `read:` frames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)