### PR TITLE
docs: consolidate usage into docs/usage.md and correct the length-cap claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,37 +10,11 @@ It fuses three disciplines:
 
 The single tool is `criticalthinking`. Every call must include the four critical-thinking fields — there is no opt-out, by design.
 
-## Install
+**Install & usage → [docs/usage.md](docs/usage.md).** One-line install:
 
 ```bash
 go install github.com/jacaudi/critical-thinking/cmd/critical-thinking@latest
-# or
-docker pull ghcr.io/jacaudi/critical-thinking:v1.8.0
 ```
-
-The Go install lands the binary at `$GOPATH/bin/critical-thinking`.
-
-## Run
-
-```bash
-# stdio (default; for Claude Desktop, Codex CLI, VS Code, etc.)
-critical-thinking serve
-
-# Streamable HTTP
-critical-thinking serve --http :3000
-
-# Docker (HTTP on :3000)
-docker run --rm -p 3000:3000 ghcr.io/jacaudi/critical-thinking:v1.8.0
-
-# CLI mode — pipe NDJSON ThoughtData directly, no MCP host required
-critical-thinking cli             # prints narrated transcript to stdout
-critical-thinking cli --json      # prints structured ThoughtResponse as NDJSON
-critical-thinking schema          # prints the tool contract (description + JSON Schemas) and exits
-```
-
-See [docs/clients.md#cli-no-mcp-host](docs/clients.md#cli-no-mcp-host) for CLI usage details and error-handling behaviour.
-
-Logs go to stderr. `--verbose` raises the level to debug (and traces JSON-RPC frames in stdio mode) and `--log-format=text|json` selects the format. See [docs/configuration.md#logging](docs/configuration.md#logging).
 
 ## One-call example
 
@@ -64,54 +38,7 @@ Response (`structuredContent`):
 { "branches": [], "thoughtHistoryLength": 1, "sessionConfidence": 0.6 }
 ```
 
-The `text` content is a rendered transcript in first-person, exploratory voice. Subsequent calls can omit `thoughtNumber` (auto-assigned) and `totalThoughts` (inherited). Every critical-thinking field has a server-side length cap to enforce one-tight-sentence discipline. The full contract lives in the tool description itself.
-
-## Client setup
-
-### Claude Code
-
-Add the server with the `claude` CLI — pick one transport.
-
-**stdio** (the binary runs as a subprocess of Claude Code):
-
-```bash
-claude mcp add critical-thinking -- critical-thinking serve
-```
-
-**Streamable HTTP** (run the server separately, point Claude Code at the URL):
-
-```bash
-critical-thinking serve --http :3000 &
-claude mcp add --transport http critical-thinking http://localhost:3000/mcp
-```
-
-Scope it with `--scope user` (available in every project for your user) or `--scope project` (committed to `.mcp.json` in the repo). Default scope is `local` (this project, your machine only).
-
-Verify with `claude mcp list`. Inside a session, `/mcp` shows server status and tools.
-
-### Other clients
-
-`mcp.json` (Claude Desktop / Codex CLI / VS Code):
-
-```json
-{
-  "mcpServers": {
-    "critical-thinking": { "command": "critical-thinking", "args": ["serve"] }
-  }
-}
-```
-
-Or HTTP:
-
-```json
-{
-  "mcpServers": {
-    "critical-thinking": { "url": "http://localhost:3000/mcp" }
-  }
-}
-```
-
-More client recipes in [docs/clients.md](docs/clients.md).
+The `text` content is a rendered transcript in first-person, exploratory voice. Subsequent calls can omit `thoughtNumber` (auto-assigned) and `totalThoughts` (inherited). Keep each field to one tight sentence — the tool description asks for that brevity; the server does not enforce a hard limit. The full contract lives in the tool description itself.
 
 ## Resources
 
@@ -119,10 +46,12 @@ The server exposes `thinking://current` — a per-session JSON snapshot of the f
 
 ## Documentation
 
-- [docs/configuration.md](docs/configuration.md) — env vars, HTTP endpoints, session lifecycle
+- [docs/usage.md](docs/usage.md) — install, MCP-server & CLI-pipe usage, a worked session
+  - [Install](docs/usage.md#install) · [As an MCP server](docs/usage.md#as-an-mcp-server) · [As a CLI pipe](docs/usage.md#as-a-cli-pipe-no-mcp-host) · [Worked session](docs/usage.md#a-worked-session)
 - [docs/clients.md](docs/clients.md) — Claude Desktop, Codex CLI, VS Code, Cursor recipes
-- [docs/development.md](docs/development.md) — building, testing, debugging with MCP Inspector
+- [docs/configuration.md](docs/configuration.md) — env vars, HTTP endpoints, [logging](docs/configuration.md#logging), CORS, session lifecycle
 - [docs/migration.md](docs/migration.md) — breaking changes since `http-sequential-thinking`
+- [docs/development.md](docs/development.md) — building, testing, debugging with MCP Inspector
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,10 @@ Reference material for `critical-thinking`. The top-level [README](../README.md)
 
 | File | Covers |
 |---|---|
+| [usage.md](usage.md) | Install, MCP-server & CLI-pipe usage, a worked session |
 | [configuration.md](configuration.md) | Env vars (`CTHINK_ALLOWED_ORIGINS`, `CTHINK_HTTP_HOST`, `CTHINK_VERBOSE`, `CTHINK_LOG_FORMAT`), HTTP endpoints, session lifecycle, idle timeout |
 | [clients.md](clients.md) | `mcp.json` snippets for Claude Desktop, Codex CLI, VS Code, Cursor — both stdio and HTTP transports |
 | [development.md](development.md) | Building, running tests with `-race`, debugging with MCP Inspector, release workflow |
 | [migration.md](migration.md) | Cumulative breaking-change log since the `http-sequential-thinking` Node predecessor |
 
-For the tool's full input contract (every field, every length cap, every rule), read the tool description itself — clients receive it on `tools/list`. Code lives in [`internal/thinking/description.go`](../internal/thinking/description.go).
+For the tool's full input contract (every field and every rule), read the tool description itself — clients receive it on `tools/list`. Code lives in [`internal/thinking/description.go`](../internal/thinking/description.go).

--- a/docs/development.md
+++ b/docs/development.md
@@ -60,4 +60,4 @@ CI runs on push and PR via GitHub Actions: `vet`, `gofmt`, `go test -race -count
 
 ## Treating the description as a protocol
 
-The string in [`internal/thinking/description.go`](../internal/thinking/description.go) is the contract every client agent reads. Treat changes there like wire-format changes: bump the package version and add an entry to [migration.md](migration.md). Field renames, length-cap changes, or removed guidance can all silently break agent behavior.
+The string in [`internal/thinking/description.go`](../internal/thinking/description.go) is the contract every client agent reads. Treat changes there like wire-format changes: bump the package version and add an entry to [migration.md](migration.md). Field renames, semantic changes, or removed guidance can all silently break agent behavior.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -85,22 +85,9 @@ The whole project was renamed to align with the discipline it teaches. Specifics
 
 ## Tool description rewritten — "Thinking out loud" replaces the rubber-duck framing
 
-The verbatim description registered on the `criticalthinking` tool was rewritten. Discipline #2 changed from "Rubber-duck narration" to "Thinking out loud." The mechanism is unchanged (first-person, exploratory voice; hedges and self-corrections welcome) but the framing is now: putting half-formed reasoning into words is itself the double-check on it. No field semantics changed; no caps changed; no required fields added or removed. Per the protocol-level treatment of `description.go`, this is a behavior-affecting change for client agents that read the tool description and adjust their voice.
+The verbatim description registered on the `criticalthinking` tool was rewritten. Discipline #2 changed from "Rubber-duck narration" to "Thinking out loud." The mechanism is unchanged (first-person, exploratory voice; hedges and self-corrections welcome) but the framing is now: putting half-formed reasoning into words is itself the double-check on it. No field semantics changed; no required fields added or removed. Per the protocol-level treatment of `description.go`, this is a behavior-affecting change for client agents that read the tool description and adjust their voice.
 
-## From `0.6.x` (post-rewrite, prior to length-cap and optional-field work)
-
-### Length caps on critical fields
-
-Server-side rune-counted maxLength on the four critical-thinking fields. Over-cap requests return `IsError: true`.
-
-| Field | Cap (runes) | Notes |
-|---|---:|---|
-| `critique` | 280 | Always enforced |
-| `counterArgument` | 280 | Always enforced |
-| `assumptions[i]` | 200 | Per-entry |
-| `nextStepRationale` | 200 | Only enforced when `nextThoughtNeeded=true` |
-
-The caps are intentionally tight. They force one-tight-sentence-per-field discipline; padded prose returns an error rather than being silently accepted. If a critique genuinely needs more than 280 chars, split the thinking across two `criticalthinking` calls — that's the design intent.
+## From `0.6.x` (post-rewrite, prior to optional-field work)
 
 ### `thoughtNumber` and `totalThoughts` are now optional after the first thought
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -77,9 +77,11 @@ read the result back.
 
 History, confidence, and branches accumulate across input lines within one run
 (the analog of a single stdio MCP session). Every line is processed; the command
-exits non-zero if any line fails (malformed JSON, validation error, or an engine
-error), writing a per-line diagnostic to stderr. Diagnostics never go to stdout,
-so a `--json` stream is always valid NDJSON.
+exits non-zero if any line fails. A malformed-JSON line is reported on stderr (in
+both modes). A line the engine rejects (for example a validation error) is
+reported on stderr in the default mode, or — in `--json` mode — emitted to stdout
+as a JSON error object (`{"error":…,"status":"failed"}`) so the `--json` stream
+stays complete and parseable line-for-line.
 
 Each `ThoughtData` line must carry the required fields — `thought`,
 `thoughtNumber`, `totalThoughts`, `nextThoughtNeeded`, `confidence` (0.0–1.0),

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,178 @@
+# Usage
+
+`critical-thinking` runs two ways: as an **MCP server** (the usual path — your AI
+host calls the `criticalthinking` tool) or as a **CLI pipe** (no MCP host — your
+own script feeds it NDJSON). Install once, then pick the path that fits.
+
+## Install
+
+```bash
+# Go toolchain (lands at $GOPATH/bin/critical-thinking)
+go install github.com/jacaudi/critical-thinking/cmd/critical-thinking@latest
+
+# Container image (pin to a release tag)
+docker pull ghcr.io/jacaudi/critical-thinking:v1.8.0
+```
+
+Prebuilt binaries for each release are attached to the
+[GitHub releases](https://github.com/jacaudi/critical-thinking/releases).
+
+## As an MCP server
+
+The default transport is stdio (what Claude Desktop, Codex CLI, VS Code, etc.
+expect); `--http` switches to Streamable HTTP.
+
+```bash
+critical-thinking serve                 # stdio (default)
+critical-thinking serve --http :3000    # Streamable HTTP on :3000
+docker run --rm -p 3000:3000 ghcr.io/jacaudi/critical-thinking:v1.8.0   # HTTP in a container
+```
+
+Register it with Claude Code using the `claude` CLI:
+
+```bash
+# stdio (Claude Code runs the binary as a subprocess)
+claude mcp add critical-thinking -- critical-thinking serve
+
+# Streamable HTTP (run the server separately, point Claude Code at the URL)
+critical-thinking serve --http :3000 &
+claude mcp add --transport http critical-thinking http://localhost:3000/mcp
+```
+
+Scope with `--scope user` (every project) or `--scope project` (committed to
+`.mcp.json`); default is `local`. Verify with `claude mcp list`; inside a session
+`/mcp` shows server status and tools.
+
+Or hand-write `mcp.json` (Claude Desktop / Codex CLI / VS Code):
+
+```json
+{
+  "mcpServers": {
+    "critical-thinking": { "command": "critical-thinking", "args": ["serve"] }
+  }
+}
+```
+
+```json
+{
+  "mcpServers": {
+    "critical-thinking": { "url": "http://localhost:3000/mcp" }
+  }
+}
+```
+
+- Full per-host recipes (Claude Desktop, Codex CLI, VS Code, Cursor): [clients.md](clients.md)
+- Env vars, HTTP host/port, CORS, logging: [configuration.md](configuration.md)
+
+## As a CLI pipe (no MCP host)
+
+`critical-thinking cli` runs the same thinking engine over stdin→stdout — no MCP
+host required. This is a first-class way to integrate: have your own agent,
+script, or orchestrator emit NDJSON `ThoughtData` (one JSON object per line) and
+read the result back.
+
+- `critical-thinking cli` prints a narrated transcript to stdout.
+- `critical-thinking cli --json` prints structured `ThoughtResponse` as NDJSON —
+  the machine-readable surface for programmatic callers.
+
+History, confidence, and branches accumulate across input lines within one run
+(the analog of a single stdio MCP session). Every line is processed; the command
+exits non-zero if any line fails (malformed JSON, validation error, or an engine
+error), writing a per-line diagnostic to stderr. Diagnostics never go to stdout,
+so a `--json` stream is always valid NDJSON.
+
+Each `ThoughtData` line must carry the required fields — `thought`,
+`thoughtNumber`, `totalThoughts`, `nextThoughtNeeded`, `confidence` (0.0–1.0),
+`assumptions` (use `[]` if none), `critique`, `counterArgument`, and
+`nextStepRationale` when `nextThoughtNeeded` is `true`. See
+[clients.md#cli-no-mcp-host](clients.md#cli-no-mcp-host) for the full
+field-by-field contract.
+
+## A worked session
+
+Three thoughts — an initial thought, a revision of it, then a branch — piped in
+as NDJSON:
+
+```bash
+critical-thinking cli <<'EOF'
+{"thought":"Reads dominate writes here, so I'll normalize the schema first.","thoughtNumber":1,"totalThoughts":3,"nextThoughtNeeded":true,"confidence":0.6,"assumptions":["read:write ratio is ~10:1"],"critique":"I jumped to a solution before confirming the ratio.","counterArgument":"If writes dominate, a denormalized store is simpler.","nextStepRationale":"Verify the read:write ratio before committing to normalization."}
+{"thought":"Correction: the measured ratio is ~2:1, so normalization is far less decisive.","thoughtNumber":2,"totalThoughts":3,"nextThoughtNeeded":true,"isRevision":true,"revisesThought":1,"confidence":0.7,"assumptions":["measured read:write ratio is 2:1"],"critique":"My first thought over-weighted reads on an unverified 10:1 guess.","counterArgument":"Even at 2:1 reads still lead, so normalizing isn't wrong, just weaker.","nextStepRationale":"Weigh write-amplification against the modest read advantage."}
+{"thought":"Branch: keep one denormalized table and accept write fan-out instead.","thoughtNumber":1,"totalThoughts":2,"nextThoughtNeeded":false,"branchFromThought":1,"branchId":"denormalized","confidence":0.5,"assumptions":["write fan-out stays under 3x"],"critique":"This trades read simplicity for a write cost I have not measured.","counterArgument":"If fan-out exceeds 3x, this branch is worse than normalizing."}
+EOF
+```
+
+Narrated output:
+
+```
+Thought 1 of 3 · confidence 0.60
+
+Reads dominate writes here, so I'll normalize the schema first.
+
+  Assumptions:
+    - read:write ratio is ~10:1
+
+  Critique:
+    I jumped to a solution before confirming the ratio.
+
+  Counter-argument:
+    If writes dominate, a denormalized store is simpler.
+
+  Next, I want to: Verify the read:write ratio before committing to normalization.
+
+— session confidence 0.60 across 1 thought
+
+Revision of thought 1 (now thought 2) · confidence 0.70
+
+Correction: the measured ratio is ~2:1, so normalization is far less decisive.
+
+  Assumptions:
+    - measured read:write ratio is 2:1
+
+  Critique:
+    My first thought over-weighted reads on an unverified 10:1 guess.
+
+  Counter-argument:
+    Even at 2:1 reads still lead, so normalizing isn't wrong, just weaker.
+
+  Next, I want to: Weigh write-amplification against the modest read advantage.
+
+— session confidence 0.65 across 2 thoughts
+
+Branch 'denormalized' from thought 1 · confidence 0.50
+
+Branch: keep one denormalized table and accept write fan-out instead.
+
+  Assumptions:
+    - write fan-out stays under 3x
+
+  Critique:
+    This trades read simplicity for a write cost I have not measured.
+
+  Counter-argument:
+    If fan-out exceeds 3x, this branch is worse than normalizing.
+
+— branch 'denormalized' confidence 0.50 across 1 thought
+— session confidence (trunk) 0.65 across 2 thoughts
+```
+
+The same input with `--json` yields one `ThoughtResponse` per line:
+
+```
+{"thoughtNumber":1,"totalThoughts":3,"nextThoughtNeeded":true,"branches":[],"thoughtHistoryLength":1,"sessionConfidence":0.6}
+{"thoughtNumber":2,"totalThoughts":3,"nextThoughtNeeded":true,"branches":[],"thoughtHistoryLength":2,"sessionConfidence":0.6499999999999999}
+{"thoughtNumber":1,"totalThoughts":2,"nextThoughtNeeded":false,"branches":["denormalized"],"thoughtHistoryLength":3,"sessionConfidence":0.6499999999999999,"branchConfidences":{"denormalized":0.5}}
+```
+
+## schema and version
+
+```bash
+critical-thinking schema    # prints the full tool contract (description + JSON Schemas) and exits
+critical-thinking version   # prints version/commit/date; --json for structured output
+```
+
+## See also
+
+- [configuration.md](configuration.md) — env vars, HTTP, logging, CORS
+- [clients.md](clients.md) — per-host MCP recipes
+- [migration.md](migration.md) — breaking changes across versions
+- [development.md](development.md) — building, testing, MCP Inspector

--- a/scripts/bump-docker-tags.mjs
+++ b/scripts/bump-docker-tags.mjs
@@ -11,7 +11,7 @@ if (!version || !/^\d+\.\d+\.\d+/.test(version)) {
   process.exit(1);
 }
 
-const targets = ["README.md", "docs/clients.md"];
+const targets = ["README.md", "docs/clients.md", "docs/usage.md"];
 const pattern = /(ghcr\.io\/jacaudi\/critical-thinking:v)\d+\.\d+\.\d+/g;
 const replacement = `$1${version}`;
 


### PR DESCRIPTION
## Summary

Phase 4 of the standards refactoring (docs/examples). Consolidates install/usage into a new `docs/usage.md`, slims the README into an overview + link hub, and corrects a documentation-accuracy bug: the docs claimed a "server-side length cap" on the four critical-thinking fields that the Go engine **has never enforced** (D1).

- **New `docs/usage.md`** — the authoritative install + usage home, presenting two peer integration paths: an MCP server (`serve` stdio/HTTP, `claude mcp add`, `mcp.json`) and the `critical-thinking cli` NDJSON pipe as a first-class no-MCP-host integration, plus a **worked session whose transcript is real binary output**.
- **Slimmed `README.md`** — overview + one-line install + one-call example + Resources + a header-level link hub to the docs + License. Install/Run/Client-setup detail moved into `docs/usage.md`; `docs/clients.md` stays the deep per-host reference.
- **D1 length-cap correction** — verified no Go release ever enforced caps (`schema.go` has no `maxLength`; `ThoughtData.Validate()` checks presence/range only; the tool description is already clean; `git log -S` across history is empty). The false claim is removed/reworded in `README.md`, `docs/README.md`, `docs/development.md`, and `docs/migration.md` (the migration "Length caps" subsection removed; the real optional-fields subsection kept).
- **`scripts/bump-docker-tags.mjs`** — `docs/usage.md` added to `targets` so its pinned image tag is bumped on release.

## No code / no release

Docs-only (+ one release-script line). No engine/schema/transport change; `docs:`/`chore:` → semantic-release cuts no version bump (stays v1.8.0).

## Independent review

A fresh full-diff review confirmed: no Go change, the cap claim is gone everywhere user-facing, the worked transcript matches the binary byte-for-byte, and all links/anchors resolve. One flagged wording bug (cli `--json` error routing) was fixed in `c83dd70` and re-verified against the binary.

## Follow-up (out of scope, noted)

A second docs-vs-engine mismatch was found: the "omit `thoughtNumber` (auto-assigned) / `totalThoughts` (inherited)" claim isn't backed by the engine (`Validate()` requires both `≥1`). Pre-existing and outside this PR's length-cap scope — candidate for a later correction.

## Test plan

- [x] Worked transcript regenerated from the built binary and matches byte-for-byte
- [x] `git grep -i 'length cap'` over user-facing `*.md` is clean
- [x] All README/usage links + header anchors resolve (incl. `clients.md#cli-no-mcp-host`, `configuration.md#logging`)
- [x] `go build ./...` green; working tree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)