### PR TITLE
fix: stop pinning closed HTTP session state; tidy slog key + docs

### DIFF
--- a/cmd/critical-thinking/config.go
+++ b/cmd/critical-thinking/config.go
@@ -21,7 +21,8 @@ func newConfigViper() *viper.Viper {
 
 // bindFlags binds the logging persistent flags to their Viper keys so a passed
 // flag overrides env overrides default. flags is the running command's flag set
-// (it inherits the root persistent flags). It errors only if a flag is missing.
+// (it inherits the root persistent flags). It returns an error only if a named
+// flag is absent from flags — BindPFlag rejects a nil *pflag.Flag.
 func bindFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 	if err := v.BindPFlag("verbose", flags.Lookup("verbose")); err != nil {
 		return err

--- a/cmd/critical-thinking/mcpserver.go
+++ b/cmd/critical-thinking/mcpserver.go
@@ -101,7 +101,7 @@ func runHTTP(cfg httpConfig, addr string) error {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
 		defer cancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {
-			slog.Error("graceful shutdown failed", "err", err)
+			slog.Error("graceful shutdown failed", "error", err)
 		}
 	}()
 

--- a/cmd/critical-thinking/mcpserver.go
+++ b/cmd/critical-thinking/mcpserver.go
@@ -11,7 +11,7 @@ import (
 	"os/signal"
 	"slices"
 	"strings"
-	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -196,29 +196,24 @@ func makeResourceHandler(state *thinking.SequentialThinkingServer) func(context.
 	}
 }
 
-// sessionRegistry counts every session ever created in this process. It does
-// NOT mediate access to states — only the factory closure that created a state
-// holds the reference used by the tool handler — and it is NOT pruned when the
-// SDK closes idle sessions (we have no callback). Treat the count as a
-// lifetime "sessions created" counter, not an "active right now" gauge.
+// sessionRegistry counts every session ever created in this process. It holds
+// only a monotonic counter — never the session states themselves — so closed
+// sessions are not pinned: the factory closure that created a state holds the
+// only live reference, and the SDK releases it on idle timeout for GC. Treat
+// the count as a lifetime "sessions created" counter, not an "active right
+// now" gauge.
 type sessionRegistry struct {
-	mu     sync.Mutex
-	states []*thinking.SequentialThinkingServer
+	created atomic.Int64
 }
 
 func newSessionRegistry() *sessionRegistry { return &sessionRegistry{} }
 
-func (r *sessionRegistry) add(s *thinking.SequentialThinkingServer) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.states = append(r.states, s)
-}
+// add records that a session was created. The *SequentialThinkingServer
+// argument is intentionally not retained (that would pin closed-session state);
+// it is kept in the signature so the call site reads naturally.
+func (r *sessionRegistry) add(*thinking.SequentialThinkingServer) { r.created.Add(1) }
 
-func (r *sessionRegistry) count() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return len(r.states)
-}
+func (r *sessionRegistry) count() int { return int(r.created.Load()) }
 
 // withCORS gates browser access via the configured allowed-origins list
 // (CTHINK_ALLOWED_ORIGINS). Empty means no browser origins allowed.

--- a/cmd/critical-thinking/mcpserver.go
+++ b/cmd/critical-thinking/mcpserver.go
@@ -198,10 +198,10 @@ func makeResourceHandler(state *thinking.SequentialThinkingServer) func(context.
 
 // sessionRegistry counts every session ever created in this process. It holds
 // only a monotonic counter — never the session states themselves — so closed
-// sessions are not pinned: the factory closure that created a state holds the
-// only live reference, and the SDK releases it on idle timeout for GC. Treat
-// the count as a lifetime "sessions created" counter, not an "active right
-// now" gauge.
+// sessions are not pinned here: the factory closure that created a state holds
+// the only live reference, leaving the state eligible for GC once the SDK
+// releases it. Treat the count as a lifetime "sessions created" counter, not an
+// "active right now" gauge.
 type sessionRegistry struct {
 	created atomic.Int64
 }

--- a/cmd/critical-thinking/mcpserver_test.go
+++ b/cmd/critical-thinking/mcpserver_test.go
@@ -67,6 +67,25 @@ func TestCORSAllowsNoOrigin(t *testing.T) {
 	}
 }
 
+// TestSessionRegistryCountsCreations characterizes the registry's only
+// behavior: count() returns the number of sessions ever added, and add() is
+// safe under concurrency. It must stay green across the slice→atomic refactor.
+func TestSessionRegistryCountsCreations(t *testing.T) {
+	r := newSessionRegistry()
+	if got := r.count(); got != 0 {
+		t.Fatalf("new registry count = %d, want 0", got)
+	}
+	const n = 50
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() { r.add(thinking.NewServer()) })
+	}
+	wg.Wait()
+	if got := r.count(); got != n {
+		t.Errorf("count after %d concurrent adds = %d, want %d", n, got, n)
+	}
+}
+
 func TestHealthEndpoint(t *testing.T) {
 	registry := newSessionRegistry()
 	registry.add(thinking.NewServer())

--- a/cmd/critical-thinking/root_test.go
+++ b/cmd/critical-thinking/root_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 )
 
+// Tests in this package install a process-global logger via slog.SetDefault
+// (through the root PersistentPreRunE and the serve logging stub). They must
+// NOT call t.Parallel: parallel tests would race on the global default logger.
+// Keep every test in this package serial.
 func TestRootBareShowsHelpAndExitsZero(t *testing.T) {
 	cmd := newRootCmd()
 	var out, errBuf bytes.Buffer


### PR DESCRIPTION
## Summary

Maintenance PR closing out the standards refactoring. Fixes a real memory leak plus three cosmetic cleanups left from the P2/P3 reviews.

### Fix: sessionRegistry no longer pins closed-session state

`sessionRegistry` (HTTP mode) held `[]*SequentialThinkingServer` guarded by a mutex and appended one pointer per session created, never pruned (no SDK close callback) — so closed-session state pointers were pinned for the whole process lifetime: monotonic memory growth on long-running HTTP servers. Since only the slice length was ever read (`/health`'s `sessionsCreated`), it's replaced with a single `atomic.Int64`. `count()` semantics are identical; the per-session state is no longer retained, so it's eligible for GC once the SDK releases it. A new `TestSessionRegistryCountsCreations` (50 concurrent `wg.Go` adds under `-race`) characterizes the counter and guards the refactor.

### Cleanups

- `slog.Error` uses the conventional `"error"` key (was `"err"`).
- A caution comment in the cmd test package: tests mutate the process-global `slog.SetDefault`, so they must not use `t.Parallel`.
- Tightened the `bindFlags` doc comment (it errors only when a named flag is absent — `BindPFlag` rejects a nil flag).

## Notes

- Behavior-preserving for `count()` / `/health`; `/health` JSON unchanged.
- Independent full-diff review: READY-TO-FINISH (0 Critical / 0 Important); the one optional Minor (comment phrasing) was applied.
- `fix:` → semantic-release cuts a patch (~v1.8.1).

## Test plan

- [x] `TestSessionRegistryCountsCreations` green before and after the refactor (regression guard; leak itself isn't unit-observable)
- [x] `/health` + cross-session/resource tests stay green
- [x] `go build`/`go vet`/`gofmt -l`/`go test -race ./...` clean; golangci-lint v2 (from source) 0 issues
- [x] `go.mod`/`go.sum` unchanged; only the 4 cmd files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)