### PR TITLE
feat(plugin): add critical-thinking Claude Code plugin (MCP install + skill + always-on hook)

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -45,6 +45,12 @@ runs:
       shell: bash
       run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
+    - name: plugin lint + tests
+      shell: bash
+      run: |
+        task lint:plugin
+        task test:plugin
+
     - name: test (race + coverage)
       shell: bash
       run: task test-race

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -12,6 +12,8 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
       - 'Dockerfile*'
+      - 'plugins/**'
+      - 'taskfile.yml'
 
 jobs:
   tests:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -40,7 +40,7 @@
       "publishCmd": "goreleaser release --clean --skip=validate"
     }],
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "README.md", "docs/clients.md", "plugins/critical-thinking/hooks/install-binary.sh"],
+      "assets": ["CHANGELOG.md", "README.md", "docs/clients.md", "docs/usage.md", "plugins/critical-thinking/hooks/install-binary.sh"],
       "message": "release: v${nextRelease.version} [skip ci]"
     }],
     ["@semantic-release/github", {

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -36,11 +36,11 @@
       "changelogTitle": "# Changelog"
     }],
     ["@semantic-release/exec", {
-      "prepareCmd": "node scripts/bump-docker-tags.mjs ${nextRelease.version}",
+      "prepareCmd": "node scripts/bump-docker-tags.mjs ${nextRelease.version} && node scripts/bump-plugin-version.mjs ${nextRelease.version}",
       "publishCmd": "goreleaser release --clean --skip=validate"
     }],
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "README.md", "docs/clients.md"],
+      "assets": ["CHANGELOG.md", "README.md", "docs/clients.md", "plugins/critical-thinking/hooks/install-binary.sh"],
       "message": "release: v${nextRelease.version} [skip ci]"
     }],
     ["@semantic-release/github", {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The single tool is `criticalthinking`. Every call must include the four critical
 go install github.com/jacaudi/critical-thinking/cmd/critical-thinking@latest
 ```
 
+Or install the **Claude Code plugin** under [`plugins/critical-thinking/`](plugins/critical-thinking/): it auto-installs the server, adds an always-on two-gate verification skill, and a hook that activates it every turn. See [its README](plugins/critical-thinking/README.md).
+
 ## One-call example
 
 Request:
@@ -52,6 +54,7 @@ The server exposes `thinking://current` — a per-session JSON snapshot of the f
 - [docs/configuration.md](docs/configuration.md) — env vars, HTTP endpoints, [logging](docs/configuration.md#logging), CORS, session lifecycle
 - [docs/migration.md](docs/migration.md) — breaking changes since `http-sequential-thinking`
 - [docs/development.md](docs/development.md) — building, testing, debugging with MCP Inspector
+- [plugins/critical-thinking/](plugins/critical-thinking/) — the Claude Code plugin (bundled server install + always-on critical-thinking skill)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,5 +9,6 @@ Reference material for `critical-thinking`. The top-level [README](../README.md)
 | [clients.md](clients.md) | `mcp.json` snippets for Claude Desktop, Codex CLI, VS Code, Cursor — both stdio and HTTP transports |
 | [development.md](development.md) | Building, running tests with `-race`, debugging with MCP Inspector, release workflow |
 | [migration.md](migration.md) | Cumulative breaking-change log since the `http-sequential-thinking` Node predecessor |
+| [../plugins/critical-thinking/](../plugins/critical-thinking/) | The Claude Code plugin — bundles the server install, the two-gate verification skill, and an always-on activation hook |
 
 For the tool's full input contract (every field and every rule), read the tool description itself — clients receive it on `tools/list`. Code lives in [`internal/thinking/description.go`](../internal/thinking/description.go).

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -34,6 +34,10 @@ claude mcp list
 
 Inside a Claude Code session, `/mcp` shows live status, and the `criticalthinking` tool will appear in tool listings.
 
+### Plugin (bundled install)
+
+Instead of the manual `claude mcp add` above, install the in-repo **Claude Code plugin** ([`plugins/critical-thinking/`](../plugins/critical-thinking/)). It registers the MCP server over stdio (downloading the binary automatically), ships the two-gate critical-thinking verification skill, and adds a hook that activates the skill on every prompt. See the [plugin README](../plugins/critical-thinking/README.md) for install, the HTTP-transport variants, and how to disable the always-on hook.
+
 ## Claude Desktop
 
 `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,10 @@
 
 Cumulative breaking-change log for `critical-thinking`. Most recent changes first.
 
+## Claude Code plugin re-introduced
+
+Non-breaking. A Claude Code **plugin** now ships in-repo under `plugins/critical-thinking/`, bundling the MCP server (auto-installed via a `SessionStart` hook), a two-gate critical-thinking verification skill, and a `UserPromptSubmit` hook that activates the skill on every prompt. This is additive packaging — the server, its `criticalthinking` tool, schema, and transports are unchanged. It reverses the earlier removal of the plugin scaffolding described below, so the note that "the project is now solely an MCP server" no longer holds. See [`plugins/critical-thinking/README.md`](../plugins/critical-thinking/README.md).
+
 ## v1.8.0 — Config via Viper; `CTHINK_` env prefix
 
 **Breaking (env var renames).** Configuration moved to Viper with the `CTHINK_` prefix:

--- a/plugins/critical-thinking/.claude-plugin/plugin.json
+++ b/plugins/critical-thinking/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "critical-thinking",
+  "description": "Always-on two-gate critical-thinking verification, backed by the critical-thinking MCP server.",
+  "version": "0.1.0",
+  "author": { "name": "jacaudi", "url": "https://github.com/jacaudi" },
+  "homepage": "https://github.com/jacaudi/critical-thinking",
+  "repository": "https://github.com/jacaudi/critical-thinking",
+  "license": "MIT"
+}

--- a/plugins/critical-thinking/.gitignore
+++ b/plugins/critical-thinking/.gitignore
@@ -1,0 +1,3 @@
+# Runtime artifact: the MCP server binary is downloaded by the SessionStart
+# install hook into this directory. Never commit it.
+/bin/

--- a/plugins/critical-thinking/.mcp.json
+++ b/plugins/critical-thinking/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "critical-thinking": {
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/critical-thinking",
+      "args": ["serve"]
+    }
+  }
+}

--- a/plugins/critical-thinking/README.md
+++ b/plugins/critical-thinking/README.md
@@ -1,0 +1,55 @@
+# critical-thinking (Claude Code plugin)
+
+Installs the [`critical-thinking`](https://github.com/jacaudi/critical-thinking) MCP server, ships the **two-gate critical-thinking verification** skill, and force-activates that skill on every prompt.
+
+## What it does
+
+1. **Installs the MCP server.** A `SessionStart` hook downloads the pinned server binary for your OS/arch into the plugin's `bin/` directory (no Go toolchain needed). The bundled `.mcp.json` launches it over stdio (`critical-thinking serve`).
+2. **Adds a skill.** `critical-thinking` runs two verification gates per substantive prompt: **Gate 1** (intent) before work, **Gate 2** (result) before responding — both via the `criticalthinking` tool.
+3. **Always on.** A `UserPromptSubmit` hook injects the two-gate protocol into every turn (trivial acknowledgements exempt).
+
+## Install
+
+Install the plugin through your Claude Code plugin marketplace / path. On the next session start the install hook fetches the binary; no manual step.
+
+The server binary version is pinned in `hooks/install-binary.sh` (`EXPECTED_VERSION`) and tracks server releases automatically.
+
+## HTTP transport (optional)
+
+The default is stdio. To use Streamable HTTP instead:
+
+### Local
+
+Run the server yourself and point the MCP entry at the URL (replace the bundled stdio `.mcp.json` `mcpServers` entry):
+
+```bash
+critical-thinking serve --http :3000
+```
+
+```json
+{ "mcpServers": { "critical-thinking": { "url": "http://localhost:3000/mcp" } } }
+```
+
+### Remote
+
+Point at a remote server URL:
+
+```json
+{ "mcpServers": { "critical-thinking": { "url": "https://your-host.example/mcp" } } }
+```
+
+For browser-origin or bind-host configuration, see the server's
+[`docs/configuration.md`](https://github.com/jacaudi/critical-thinking/blob/main/docs/configuration.md)
+(`CTHINK_ALLOWED_ORIGINS`, `CTHINK_HTTP_HOST`).
+
+## Disabling the always-on hook
+
+The activation hook is always-on by default. To fall back to description-driven
+auto-invocation (the model decides when to run the skill) without the per-turn
+forcing, remove the `UserPromptSubmit` block from `hooks/hooks.json` in your
+installed copy, or disable the plugin's hooks via your Claude Code settings. The
+skill itself still loads and auto-triggers from its description.
+
+## License
+
+[MIT](https://github.com/jacaudi/critical-thinking/blob/main/LICENSE).

--- a/plugins/critical-thinking/hooks/activate.sh
+++ b/plugins/critical-thinking/hooks/activate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: inject the always-on critical-thinking two-gate
+# protocol into the model's context for this turn. A hook cannot invoke a skill;
+# it injects the standing instruction and the model runs the gates.
+set -euo pipefail
+
+read -r -d '' CONTEXT <<'EOF' || true
+CRITICAL-THINKING PROTOCOL (always on). This prompt is subject to two mandatory verification gates using the `criticalthinking` tool. Skip ONLY trivial acknowledgements ("thanks", "got it").
+
+Gate 1 — Intent (BEFORE any work): run a `criticalthinking` session to restate the ask in your own words, separate the real ask from the stated ask, surface the assumptions you are about to make, and flag ambiguities. Only then begin work.
+
+Gate 2 — Result (BEFORE responding): run a `criticalthinking` session to verify the result actually answers what was asked, check for drift or missed requirements, confirm completeness, and decide on caveats.
+
+Scale gate depth to complexity (simple: 2-3 thoughts; medium: 5-7; complex: 10+). If the `criticalthinking` tool is unavailable (absent from tools, or a connection/transport error — not a schema error), HALT and tell the user; do not silently proceed.
+EOF
+
+jq -n --arg ctx "${CONTEXT}" \
+  '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $ctx}}'

--- a/plugins/critical-thinking/hooks/hooks.json
+++ b/plugins/critical-thinking/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "description": "critical-thinking plugin: install the MCP binary at session start, and force the two-gate discipline on every prompt.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/install-binary.sh\"",
+            "async": false
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/activate.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/critical-thinking/hooks/hooks.json
+++ b/plugins/critical-thinking/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|clear|compact",
+        "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",

--- a/plugins/critical-thinking/hooks/install-binary.sh
+++ b/plugins/critical-thinking/hooks/install-binary.sh
@@ -40,11 +40,12 @@ if [[ -x "${BIN_PATH}" && -f "${INSTALLED_VERSION_FILE}" ]]; then
   fi
 fi
 
-case "$(uname -s)" in
+UNAME_S="$(uname -s)"
+case "${UNAME_S}" in
   Linux*)               OS=linux ;;
   Darwin*)              OS=darwin ;;
   MINGW*|MSYS*|CYGWIN*) OS=windows ;;
-  *) echo "critical-thinking: unsupported OS: $(uname -s)" >&2; exit 1 ;;
+  *) echo "critical-thinking: unsupported OS: ${UNAME_S}" >&2; exit 1 ;;
 esac
 
 case "$(uname -m)" in
@@ -61,16 +62,16 @@ URL="https://github.com/${REPO}/releases/download/${EXPECTED_VERSION}/${PROJECT}
 echo "critical-thinking: installing ${EXPECTED_VERSION} from ${URL}" >&2
 
 mkdir -p "${BIN_DIR}"
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "${TMPDIR}"' EXIT
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
 
 download_ok=1
 if [[ "${EXT}" == "tar.gz" ]]; then
-  curl -fsSL "${URL}" | tar -xzC "${TMPDIR}" || download_ok=0
+  curl -fsSL "${URL}" | tar -xzC "${WORK_DIR}" || download_ok=0
 else
-  curl -fsSL -o "${TMPDIR}/release.zip" "${URL}" || download_ok=0
+  curl -fsSL -o "${WORK_DIR}/release.zip" "${URL}" || download_ok=0
   if [[ "${download_ok}" == "1" ]]; then
-    unzip -q "${TMPDIR}/release.zip" -d "${TMPDIR}" || download_ok=0
+    unzip -q "${WORK_DIR}/release.zip" -d "${WORK_DIR}" || download_ok=0
   fi
 fi
 
@@ -84,8 +85,8 @@ if [[ "${download_ok}" == "0" ]]; then
   exit 1
 fi
 
-SRC="${TMPDIR}/${PROJECT}"
-[[ "${OS}" == "windows" ]] && SRC="${TMPDIR}/${PROJECT}.exe"
+SRC="${WORK_DIR}/${PROJECT}"
+[[ "${OS}" == "windows" ]] && SRC="${WORK_DIR}/${PROJECT}.exe"
 
 if [[ ! -f "${SRC}" ]]; then
   echo "critical-thinking: archive did not contain ${SRC}" >&2

--- a/plugins/critical-thinking/hooks/install-binary.sh
+++ b/plugins/critical-thinking/hooks/install-binary.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Download the critical-thinking MCP server binary from a pinned GitHub Release
+# for the current platform into ${CLAUDE_PLUGIN_ROOT}/bin/ so the plugin's
+# .mcp.json can launch it without a Go toolchain.
+#
+# Update model: EXPECTED_VERSION is the source of truth for which binary the
+# plugin expects. semantic-release auto-bumps it on every release (see
+# scripts/bump-plugin-version.mjs + .releaserc.json). On `claude plugin update`
+# the new script arrives, the version mismatch fires, and the binary refreshes
+# on next session start. No runtime API calls, no TTL guessing.
+#
+# Behavior:
+#   - Binary present AND .installed-version == EXPECTED_VERSION -> no-op.
+#   - Otherwise -> download EXPECTED_VERSION's archive, install, record version.
+#   - Download fails AND a binary already exists -> keep it, warn, exit 0.
+#   - Download fails AND no binary exists -> fail loudly (exit 1).
+#
+# Force re-download: delete ${CLAUDE_PLUGIN_ROOT}/bin/critical-thinking.
+# Windows note: requires Git Bash / WSL / another POSIX shell.
+
+set -euo pipefail
+
+REPO="jacaudi/critical-thinking"
+PROJECT="critical-thinking"
+
+# DO NOT EDIT BY HAND. Auto-bumped on every release by semantic-release
+# (scripts/bump-plugin-version.mjs via .releaserc.json @semantic-release/exec).
+EXPECTED_VERSION="v1.8.1"
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")"/.. && pwd)}"
+BIN_DIR="${PLUGIN_ROOT}/bin"
+BIN_PATH="${BIN_DIR}/${PROJECT}"
+INSTALLED_VERSION_FILE="${BIN_DIR}/.installed-version"
+
+# Fast path: binary present and at the expected version.
+if [[ -x "${BIN_PATH}" && -f "${INSTALLED_VERSION_FILE}" ]]; then
+  installed_tag="$(cat "${INSTALLED_VERSION_FILE}" 2>/dev/null || echo "")"
+  if [[ "${installed_tag}" == "${EXPECTED_VERSION}" ]]; then
+    exit 0
+  fi
+fi
+
+case "$(uname -s)" in
+  Linux*)               OS=linux ;;
+  Darwin*)              OS=darwin ;;
+  MINGW*|MSYS*|CYGWIN*) OS=windows ;;
+  *) echo "critical-thinking: unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+case "$(uname -m)" in
+  x86_64|amd64)  ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) echo "critical-thinking: unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+VERSION="${EXPECTED_VERSION#v}"
+EXT="tar.gz"
+[[ "${OS}" == "windows" ]] && EXT="zip"
+URL="https://github.com/${REPO}/releases/download/${EXPECTED_VERSION}/${PROJECT}_${VERSION}_${OS}_${ARCH}.${EXT}"
+
+echo "critical-thinking: installing ${EXPECTED_VERSION} from ${URL}" >&2
+
+mkdir -p "${BIN_DIR}"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+download_ok=1
+if [[ "${EXT}" == "tar.gz" ]]; then
+  curl -fsSL "${URL}" | tar -xzC "${TMPDIR}" || download_ok=0
+else
+  curl -fsSL -o "${TMPDIR}/release.zip" "${URL}" || download_ok=0
+  if [[ "${download_ok}" == "1" ]]; then
+    unzip -q "${TMPDIR}/release.zip" -d "${TMPDIR}" || download_ok=0
+  fi
+fi
+
+# Download failure: tolerate it if we already have *some* binary; otherwise fail.
+if [[ "${download_ok}" == "0" ]]; then
+  if [[ -x "${BIN_PATH}" ]]; then
+    echo "critical-thinking: download failed; keeping existing binary at ${BIN_PATH}" >&2
+    exit 0
+  fi
+  echo "critical-thinking: download failed and no existing binary — check network or install manually" >&2
+  exit 1
+fi
+
+SRC="${TMPDIR}/${PROJECT}"
+[[ "${OS}" == "windows" ]] && SRC="${TMPDIR}/${PROJECT}.exe"
+
+if [[ ! -f "${SRC}" ]]; then
+  echo "critical-thinking: archive did not contain ${SRC}" >&2
+  exit 1
+fi
+
+mv "${SRC}" "${BIN_PATH}"
+chmod +x "${BIN_PATH}"
+printf '%s\n' "${EXPECTED_VERSION}" > "${INSTALLED_VERSION_FILE}"
+echo "critical-thinking: installed ${BIN_PATH} (${EXPECTED_VERSION})" >&2

--- a/plugins/critical-thinking/skills/critical-thinking/SKILL.md
+++ b/plugins/critical-thinking/skills/critical-thinking/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: critical-thinking
+description: Mandatory critical-thinking gates that verify intent before work and verify results before responding, using the criticalthinking MCP tool. Always on for substantive prompts.
+disable-model-invocation: false
+user-invocable: true
+---
+
+# Critical Thinking Verification
+
+**Every substantive prompt requires two verification gates using the `criticalthinking` tool. No exceptions.**
+
+This rule applies to all prompts that involve action, analysis, or decision-making. Trivial acknowledgements ("thanks", "got it") are exempt.
+
+The tool's fully-qualified id under this plugin is `mcp__plugin_critical-thinking_critical-thinking__criticalthinking`; it is referred to as `criticalthinking` below.
+
+---
+
+## Gate 1: Intent Verification (Before Starting Work)
+
+After receiving a user prompt, **before doing anything else**, call `criticalthinking` to:
+
+1. Restate what the user is asking in your own words
+2. Identify the real ask vs. the stated ask (they often differ)
+3. Surface assumptions you're about to make
+4. Flag ambiguities that could send you in the wrong direction
+5. Decide whether to ask clarifying questions or proceed
+
+**Use extended thinking throughout this gate.** Think through edge cases, implicit requirements, and unstated context.
+
+Only after this gate passes should you begin work (research, coding, planning, etc.).
+
+---
+
+## Gate 2: Result Verification (Before Responding)
+
+After completing work but **before presenting results to the user**, call `criticalthinking` to:
+
+1. Verify the result actually answers what was asked (not what you assumed)
+2. Check for logical errors, missed requirements, or drift from the original intent
+3. Confirm completeness — did you address the full scope or only part?
+4. Identify anything that should be flagged as uncertain or incomplete
+5. Decide if the answer needs caveats or follow-up suggestions
+
+**Use extended thinking throughout this gate.** Challenge your own work before presenting it.
+
+---
+
+## Extended Thinking: Use Liberally
+
+Between the two gates, continue to use extended thinking for any non-trivial reasoning step. The gates are checkpoints; thinking is continuous.
+
+---
+
+## Tool Failure Protocol
+
+**If `criticalthinking` is unavailable at any point — HALT IMMEDIATELY.**
+
+"Unavailable" means the tool is absent from the available tools list, or a call returns a connection/transport error. A schema-validation error is NOT unavailability — that is a caller bug to fix.
+
+Do not:
+- Silently continue without verification
+- Substitute your own internal reasoning as "good enough"
+- Mention the failure in passing and proceed anyway
+- Retry silently and pretend it worked
+- Silently fall back to `mcp__sequential-thinking__sequentialthinking` or plain prose
+
+Do:
+- Stop all work in progress
+- Tell the user explicitly: "The criticalthinking tool is unavailable. I cannot verify my understanding/results without it. How would you like to proceed?"
+- Wait for user direction before continuing
+
+**This is a hard stop, not a soft warning.** The verification gates exist because unverified work causes bugs. Skipping them silently defeats the purpose.
+
+---
+
+## Workflow Summary
+
+```
+User prompt received
+  │
+  ▼
+GATE 1: Intent Verification  (criticalthinking → understand; extended thinking ON)
+  │  (If tool unavailable → HALT, alert user)
+  ▼
+WORK: Execute the task       (extended thinking throughout)
+  │
+  ▼
+GATE 2: Result Verification  (criticalthinking → validate; extended thinking ON)
+  │  (If tool unavailable → HALT, alert user)
+  ▼
+Present verified results to user
+```
+
+---
+
+## Scaling
+
+| Complexity | Gate 1 Depth | Gate 2 Depth |
+|-----------|--------------|--------------|
+| Simple (rename, typo fix) | 2-3 thoughts | 2-3 thoughts |
+| Medium (feature, bug fix) | 5-7 thoughts | 5-7 thoughts |
+| Complex (architecture, multi-file) | 10+ thoughts | 10+ thoughts |
+
+Scale verification depth to task complexity. Simple tasks still get verified — just briefly.
+
+---
+
+## Relationship to sequential-thinking
+
+`criticalthinking` is sequential-thinking with the discipline enforced by the schema (required `confidence`, `assumptions`, `critique`, `counterArgument`, `nextStepRationale`). When this skill is active, use `criticalthinking` for both gates — do not fall back to `mcp__sequential-thinking__sequentialthinking`, which has the weaker contract.

--- a/plugins/critical-thinking/test/activate_test.sh
+++ b/plugins/critical-thinking/test/activate_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Verifies activate.sh emits valid UserPromptSubmit hook JSON carrying the
+# two-gate protocol text.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/../hooks/activate.sh"
+
+out="$(bash "${SCRIPT}")" || { echo "FAIL - script errored"; exit 1; }
+
+# Valid JSON?
+echo "${out}" | jq -e . >/dev/null || { echo "FAIL - not valid JSON"; exit 1; }
+# Correct event name?
+echo "${out}" | jq -e '.hookSpecificOutput.hookEventName == "UserPromptSubmit"' >/dev/null \
+  || { echo "FAIL - wrong/absent hookEventName"; exit 1; }
+# additionalContext mentions both gates and the tool?
+ctx="$(echo "${out}" | jq -r '.hookSpecificOutput.additionalContext')"
+for needle in "Gate 1" "Gate 2" "criticalthinking" "HALT"; do
+  case "${ctx}" in *"${needle}"*) ;; *) echo "FAIL - context missing '${needle}'"; exit 1;; esac
+done
+echo "ok - activate.sh emits valid protocol JSON"

--- a/plugins/critical-thinking/test/install-binary_test.sh
+++ b/plugins/critical-thinking/test/install-binary_test.sh
@@ -63,8 +63,10 @@ new_root; stub_success
 printf 'old\n' > "${ROOT}/bin/.installed-version"
 bash "${SCRIPT}"; rc=$?
 check "mismatch downloads new binary" 0 "${rc}"
-[[ -x "${ROOT}/bin/critical-thinking" ]] && echo "ok   - binary installed" && PASS=$((PASS+1)) || { echo "FAIL - binary missing"; FAIL=$((FAIL+1)); }
-[[ "$(cat "${ROOT}/bin/.installed-version" 2>/dev/null)" == "${EXPECTED}" ]] && echo "ok   - installed-version recorded" && PASS=$((PASS+1)) || { echo "FAIL - installed-version not recorded"; FAIL=$((FAIL+1)); }
+if [[ -x "${ROOT}/bin/critical-thinking" ]]; then echo "ok   - binary installed"; PASS=$((PASS+1));
+else echo "FAIL - binary missing"; FAIL=$((FAIL+1)); fi
+if [[ "$(cat "${ROOT}/bin/.installed-version" 2>/dev/null)" == "${EXPECTED}" ]]; then echo "ok   - installed-version recorded"; PASS=$((PASS+1));
+else echo "FAIL - installed-version not recorded"; FAIL=$((FAIL+1)); fi
 
 # Case 3: download fails but an existing binary is kept (exit 0).
 new_root; stub_fail

--- a/plugins/critical-thinking/test/install-binary_test.sh
+++ b/plugins/critical-thinking/test/install-binary_test.sh
@@ -64,6 +64,7 @@ printf 'old\n' > "${ROOT}/bin/.installed-version"
 bash "${SCRIPT}"; rc=$?
 check "mismatch downloads new binary" 0 "${rc}"
 [[ -x "${ROOT}/bin/critical-thinking" ]] && echo "ok   - binary installed" && PASS=$((PASS+1)) || { echo "FAIL - binary missing"; FAIL=$((FAIL+1)); }
+[[ "$(cat "${ROOT}/bin/.installed-version" 2>/dev/null)" == "${EXPECTED}" ]] && echo "ok   - installed-version recorded" && PASS=$((PASS+1)) || { echo "FAIL - installed-version not recorded"; FAIL=$((FAIL+1)); }
 
 # Case 3: download fails but an existing binary is kept (exit 0).
 new_root; stub_fail

--- a/plugins/critical-thinking/test/install-binary_test.sh
+++ b/plugins/critical-thinking/test/install-binary_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Tests for install-binary.sh. Each case runs the script in an isolated fake
+# CLAUDE_PLUGIN_ROOT with curl/tar stubbed on PATH so no network is touched.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${HERE}/../hooks/install-binary.sh"
+PASS=0
+FAIL=0
+
+check() { # desc, expected_rc, actual_rc
+  if [[ "$2" == "$3" ]]; then echo "ok   - $1"; PASS=$((PASS+1));
+  else echo "FAIL - $1 (expected rc=$2 got rc=$3)"; FAIL=$((FAIL+1)); fi
+}
+
+# Build a throwaway plugin root with a stub bin/ dir on PATH.
+new_root() {
+  ROOT="$(mktemp -d)"
+  STUB="$(mktemp -d)"
+  mkdir -p "${ROOT}/bin"
+  export CLAUDE_PLUGIN_ROOT="${ROOT}"
+  export PATH="${STUB}:${PATH}"
+  STUBDIR="${STUB}"
+}
+
+# Stub curl/tar that "downloads" a fake binary into the extraction dir.
+stub_success() {
+  cat >"${STUBDIR}/curl" <<'EOS'
+#!/usr/bin/env bash
+# locate -C target dir from a piped tar, or -o file; emulate by writing marker
+# We cooperate with the tar stub below via a shared temp marker file.
+exit 0
+EOS
+  cat >"${STUBDIR}/tar" <<'EOS'
+#!/usr/bin/env bash
+# args: -xzC <dir> ; create the expected binary there.
+dir=""; prev=""
+for a in "$@"; do [[ "$prev" == "-C" || "$prev" == "-xzC" ]] && dir="$a"; prev="$a"; done
+[[ -z "$dir" ]] && for a in "$@"; do [[ -d "$a" ]] && dir="$a"; done
+printf '#!/bin/sh\necho cthink\n' > "${dir}/critical-thinking"
+exit 0
+EOS
+  chmod +x "${STUBDIR}/curl" "${STUBDIR}/tar"
+}
+
+# Stub curl that fails (network error).
+stub_fail() {
+  printf '#!/usr/bin/env bash\nexit 22\n' > "${STUBDIR}/curl"; chmod +x "${STUBDIR}/curl"
+  printf '#!/usr/bin/env bash\nexit 0\n'  > "${STUBDIR}/tar";  chmod +x "${STUBDIR}/tar"
+}
+
+# Case 1: fast-path no-op when binary present at expected version.
+new_root
+EXPECTED="$(grep -E '^EXPECTED_VERSION=' "${SCRIPT}" | head -1 | cut -d'"' -f2)"
+printf 'stub\n' > "${ROOT}/bin/critical-thinking"; chmod +x "${ROOT}/bin/critical-thinking"
+printf '%s\n' "${EXPECTED}" > "${ROOT}/bin/.installed-version"
+# No curl/tar on PATH would break it ONLY if it tried to download; ensure it doesn't.
+printf '#!/usr/bin/env bash\necho "curl must not run" >&2; exit 99\n' > "${STUBDIR}/curl"; chmod +x "${STUBDIR}/curl"
+bash "${SCRIPT}"; check "fast-path no-op when version matches" 0 $?
+
+# Case 2: version mismatch triggers a (stubbed) successful download.
+new_root; stub_success
+printf 'old\n' > "${ROOT}/bin/.installed-version"
+bash "${SCRIPT}"; rc=$?
+check "mismatch downloads new binary" 0 "${rc}"
+[[ -x "${ROOT}/bin/critical-thinking" ]] && echo "ok   - binary installed" && PASS=$((PASS+1)) || { echo "FAIL - binary missing"; FAIL=$((FAIL+1)); }
+
+# Case 3: download fails but an existing binary is kept (exit 0).
+new_root; stub_fail
+printf 'stub\n' > "${ROOT}/bin/critical-thinking"; chmod +x "${ROOT}/bin/critical-thinking"
+printf 'old\n' > "${ROOT}/bin/.installed-version"
+bash "${SCRIPT}"; check "download fail + existing binary tolerated" 0 $?
+
+# Case 4: download fails and no binary exists (exit 1).
+new_root; stub_fail
+bash "${SCRIPT}"; check "download fail + no binary fails loudly" 1 $?
+
+echo "---"; echo "PASS=${PASS} FAIL=${FAIL}"
+[[ "${FAIL}" -eq 0 ]]

--- a/scripts/bump-plugin-version.mjs
+++ b/scripts/bump-plugin-version.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Bumps EXPECTED_VERSION in the plugin's install-binary.sh to the next release
+// version. Invoked by semantic-release (@semantic-release/exec prepareCmd):
+//   node scripts/bump-plugin-version.mjs ${nextRelease.version}
+// A second arg overrides the target file (used by tests).
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+/.test(version)) {
+  console.error(`bump-plugin-version: expected a semver argument, got: ${version}`);
+  process.exit(1);
+}
+
+const target =
+  process.argv[3] || "plugins/critical-thinking/hooks/install-binary.sh";
+const tag = `v${version}`;
+const pattern = /^EXPECTED_VERSION="v\d+\.\d+\.\d+"/m;
+
+const before = readFileSync(target, "utf8");
+if (!pattern.test(before)) {
+  console.error(`bump-plugin-version: no EXPECTED_VERSION line in ${target}`);
+  process.exit(1);
+}
+const after = before.replace(pattern, `EXPECTED_VERSION="${tag}"`);
+if (after !== before) {
+  writeFileSync(target, after);
+  console.log(`bump-plugin-version: ${target} -> ${tag}`);
+} else {
+  console.log(`bump-plugin-version: ${target} already at ${tag}`);
+}

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -27,6 +27,14 @@ tasks:
   lint:
     cmds:
       - golangci-lint run ./...
+  lint:plugin:
+    cmds:
+      - shellcheck plugins/critical-thinking/hooks/*.sh plugins/critical-thinking/test/*.sh
+      - 'for f in plugins/critical-thinking/.mcp.json plugins/critical-thinking/hooks/hooks.json plugins/critical-thinking/.claude-plugin/plugin.json; do jq -e . "$f" >/dev/null; done'
+  test:plugin:
+    cmds:
+      - bash plugins/critical-thinking/test/install-binary_test.sh
+      - bash plugins/critical-thinking/test/activate_test.sh
   clean:
     cmds:
       - rm -rf bin/ coverage.txt


### PR DESCRIPTION
## Summary

Adds an in-repo Claude Code **plugin** under `plugins/critical-thinking/` that bundles three things:

1. **Installs the MCP server** — a `SessionStart` hook (`hooks/install-binary.sh`) downloads the pinned `jacaudi/critical-thinking` release binary for the host OS/arch into `${CLAUDE_PLUGIN_ROOT}/bin/` (no Go toolchain needed), and a stdio `.mcp.json` launches it as `critical-thinking serve`. The `serve` arg is mandatory post-v1.6.0 (bare invocation prints help).
2. **Provides a skill** — `skills/critical-thinking/SKILL.md`: a two-gate verification discipline (Gate 1 = intent before work, Gate 2 = result before responding) using the `criticalthinking` tool, with a HALT-on-unavailable protocol. Ported from the repo's `sequential-thinking-verification.md` with the tool substituted.
3. **Always activates the skill** — a `UserPromptSubmit` hook (`hooks/activate.sh`) injects the two-gate protocol into every turn (a hook can't invoke a skill, so it injects context). Trivial acknowledgements exempt.

Plus: `.claude-plugin/plugin.json` manifest, a plugin `README.md` (stdio default + HTTP local/remote + how to disable the always-on hook), release wiring so the installer's `EXPECTED_VERSION` auto-bumps on each release (`scripts/bump-plugin-version.mjs` + `.releaserc.json`), and CI/Task wiring (`taskfile.yml` `lint:plugin`/`test:plugin`, the tests composite action, `on-push-main.yml` paths). The runtime-downloaded `plugins/critical-thinking/bin/` is gitignored.

No Go engine, schema, or transport code changed.

## Test Plan

Automated (green in CI via the new `lint:plugin` + `test:plugin` gate):
- [x] `shellcheck` clean on all hook + test scripts
- [x] `install-binary_test.sh` — 6/6 cases (fast-path no-op, version-mismatch download, `.installed-version` recorded, download-fail-tolerated, download-fail-fails-loud), curl/tar stubbed (no network)
- [x] `activate_test.sh` — emits valid `UserPromptSubmit` JSON carrying both gates
- [x] `bump-plugin-version.mjs` — rewrites `EXPECTED_VERSION`, idempotent, rejects non-semver
- [x] `jq` validity on `.mcp.json` / `hooks.json` / `plugin.json`
- [x] `task vet && task test` unaffected (Go suite green)

Manual (cannot run in CI — for reviewer follow-up):
- [ ] Install the plugin locally; on session start confirm `bin/critical-thinking` is populated and the `criticalthinking` tool appears
- [ ] Send a substantive prompt; confirm Gate 1 fires before work and Gate 2 before the reply
- [ ] Make the server unavailable; confirm the skill's HALT protocol triggers instead of silent fallback

## Notes

- Cross-file contracts were verified against `cmd/critical-thinking/root.go` (stdio `serve`) and `.goreleaser.yaml` (archive naming / OS-arch matrix).
- This is a `feat`, so on merge semantic-release cuts a minor release and the prepare step bumps the installer's `EXPECTED_VERSION` to that version (the matching goreleaser artifacts ship in the same release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)