### PR TITLE
docs: sync docs with current engine behavior

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -40,7 +40,7 @@
       "publishCmd": "goreleaser release --clean --skip=validate"
     }],
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "README.md", "docs/clients.md"],
+      "assets": ["CHANGELOG.md", "README.md", "docs/clients.md", "docs/usage.md"],
       "message": "release: v${nextRelease.version} [skip ci]"
     }],
     ["@semantic-release/github", {

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -40,7 +40,7 @@
       "publishCmd": "goreleaser release --clean --skip=validate"
     }],
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "README.md", "docs/clients.md", "docs/usage.md"],
+      "assets": ["CHANGELOG.md", "README.md", "docs/clients.md", "docs/usage.md", "plugins/critical-thinking/hooks/install-binary.sh"],
       "message": "release: v${nextRelease.version} [skip ci]"
     }],
     ["@semantic-release/github", {

--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ Request:
 Response (`structuredContent`):
 
 ```json
-{ "branches": [], "thoughtHistoryLength": 1, "sessionConfidence": 0.6 }
+{
+  "thoughtNumber": 1, "totalThoughts": 3, "nextThoughtNeeded": true,
+  "branches": [], "thoughtHistoryLength": 1, "sessionConfidence": 0.6
+}
 ```
 
-The `text` content is a rendered transcript in first-person, exploratory voice. Subsequent calls can omit `thoughtNumber` (auto-assigned) and `totalThoughts` (inherited). Keep each field to one tight sentence — the tool description asks for that brevity; the server does not enforce a hard limit. The full contract lives in the tool description itself.
+The `text` content is a rendered transcript in first-person, exploratory voice. Every call must send `thoughtNumber` and `totalThoughts` (both required, ≥ 1); if `thoughtNumber` exceeds `totalThoughts` the server raises `totalThoughts` to match. Keep each field to one tight sentence — the tool description asks for that brevity; the server does not enforce a hard limit. The full contract lives in the tool description itself.
 
 ## Resources
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -41,9 +41,17 @@ The inspector lets you call `criticalthinking` interactively, watch the rendered
 
 ```
 .
-├── cmd/critical-thinking/
-│   ├── main.go                   # MCP transport adapter (stdio + HTTP)
-│   └── main_test.go              # cross-session isolation integration test
+├── cmd/critical-thinking/        # Cobra command tree + MCP/CLI adapters
+│   ├── main.go                   # entry point: builds the root command, maps errors to exit codes
+│   ├── root.go                   # root command, persistent --verbose/--log-format flags
+│   ├── serve.go                  # `serve` command: stdio vs --http path selection
+│   ├── mcpserver.go              # MCP server wiring (stdio + Streamable HTTP), CORS/CSRF, /health
+│   ├── cli.go                    # `cli` command: NDJSON stdin→stdout, no MCP host
+│   ├── config.go                 # Viper config (CTHINK_ prefix), httpConfig
+│   ├── logging.go                # slog logger construction (text|json → stderr)
+│   ├── schema.go                 # `schema` command: prints the tool contract
+│   ├── version.go                # `version` command + --version text
+│   └── *_test.go                 # command + integration tests (cross-session isolation, etc.)
 ├── internal/thinking/
 │   ├── description.go            # tool description (the prompt-engineering contract)
 │   ├── schema.go                 # ThoughtData / ThoughtResponse + Validate()
@@ -52,7 +60,9 @@ The inspector lets you call `criticalthinking` interactively, watch the rendered
 ├── Dockerfile                    # multi-stage, distroless final
 ```
 
-The `internal/thinking` package has zero dependency on the MCP SDK — `cmd/critical-thinking/main.go` is the only adapter. That keeps the state machine fully unit-testable.
+The `internal/thinking` package has zero dependency on the MCP SDK — the
+`cmd/critical-thinking` package is the only adapter. That keeps the state
+machine fully unit-testable.
 
 ## Release workflow
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -87,32 +87,41 @@ The whole project was renamed to align with the discipline it teaches. Specifics
 
 The verbatim description registered on the `criticalthinking` tool was rewritten. Discipline #2 changed from "Rubber-duck narration" to "Thinking out loud." The mechanism is unchanged (first-person, exploratory voice; hedges and self-corrections welcome) but the framing is now: putting half-formed reasoning into words is itself the double-check on it. No field semantics changed; no required fields added or removed. Per the protocol-level treatment of `description.go`, this is a behavior-affecting change for client agents that read the tool description and adjust their voice.
 
-## From `0.6.x` (post-rewrite, prior to optional-field work)
+## From `0.6.x` (post-rewrite)
 
-### `thoughtNumber` and `totalThoughts` are now optional after the first thought
+### `thoughtNumber` and `totalThoughts` are required on every call
 
-- Omit `thoughtNumber` to let the server auto-assign:
-  - **Trunk** thoughts: `len(history)+1`.
-  - **Branch** thoughts (when `branchFromThought` and `branchId` are set): position within the branch (1, 2, 3, …) — **not** a global ordinal.
-  - **Revisions** (when `isRevision` and `revisesThought` are set): next trunk slot.
-- Omit `totalThoughts` to inherit the most recent **trunk** thought's value. Branch thoughts are explicitly skipped during inheritance so a branch's auto-bumped `totalThoughts` cannot contaminate the trunk's running estimate.
-- The first trunk thought of a session must still send `totalThoughts` explicitly; omitting it returns `IsError: true`.
-- Sending values explicitly is still accepted and overrides — useful for unambiguous revisions or when a client treats `thoughtNumber` as a global ordinal.
+Both fields are mandatory on **every** call and must be ≥ 1 — there is no
+auto-assign or inheritance in this Go server. A call that omits either (so it
+unmarshals to `0`) is rejected with `IsError: true`. The only server-side
+adjustment is a clamp: if `thoughtNumber` exceeds `totalThoughts`, the server
+raises `totalThoughts` to equal `thoughtNumber`.
 
-### Response no longer echoes `thoughtNumber` / `totalThoughts` / `nextThoughtNeeded`
+> Earlier docs described an "optional fields" feature (omit `thoughtNumber` to
+> auto-assign, omit `totalThoughts` to inherit) carried over from the
+> TypeScript predecessor. That behavior was never implemented in the Go port;
+> the requirement above is authoritative.
 
-The caller already sent these — echoing them was pure redundancy. The response now contains only:
+### Response includes `thoughtNumber` / `totalThoughts` / `nextThoughtNeeded`
+
+The structured response (`ThoughtResponse`) echoes the call's own
+`thoughtNumber`, `totalThoughts`, and `nextThoughtNeeded` alongside the
+session-derived fields:
 
 ```json
 {
+  "thoughtNumber": N,
+  "totalThoughts": M,
+  "nextThoughtNeeded": true,
   "branches": [...],
-  "thoughtHistoryLength": N,
+  "thoughtHistoryLength": K,
   "sessionConfidence": 0.X,
   "branchConfidences": { ... }
 }
 ```
 
-Read the full per-thought state from the `thinking://current` resource if needed.
+`branchConfidences` is present only when at least one branch exists. Read the
+full per-thought state from the `thinking://current` resource if needed.
 
 ### Binary, server name, and log line renamed to `rubber-ducky-mcp`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ own script feeds it NDJSON). Install once, then pick the path that fits.
 go install github.com/jacaudi/critical-thinking/cmd/critical-thinking@latest
 
 # Container image (pin to a release tag)
-docker pull ghcr.io/jacaudi/critical-thinking:v1.8.0
+docker pull ghcr.io/jacaudi/critical-thinking:v1.8.1
 ```
 
 Prebuilt binaries for each release are attached to the
@@ -25,7 +25,7 @@ expect); `--http` switches to Streamable HTTP.
 ```bash
 critical-thinking serve                 # stdio (default)
 critical-thinking serve --http :3000    # Streamable HTTP on :3000
-docker run --rm -p 3000:3000 ghcr.io/jacaudi/critical-thinking:v1.8.0   # HTTP in a container
+docker run --rm -p 3000:3000 ghcr.io/jacaudi/critical-thinking:v1.8.1   # HTTP in a container
 ```
 
 Register it with Claude Code using the `claude` CLI:


### PR DESCRIPTION
## Summary

Corrects four documentation drift items found by reading the docs against the actual code (no engine changes):

- **README** — the response example now includes `thoughtNumber` / `totalThoughts` / `nextThoughtNeeded` (the real `ThoughtResponse` fields per `internal/thinking/schema.go`); removed the false "subsequent calls can omit `thoughtNumber`/`totalThoughts`" claim (`Validate()` requires both `>= 1`, the only adjustment being the clamp when `thoughtNumber > totalThoughts`).
- **docs/migration.md** — corrected the two "From 0.6.x" subsections that described TypeScript-predecessor behavior (optional fields; trimmed response) never ported to the Go server.
- **docs/usage.md** — bumped the Docker tags `v1.8.0` → `v1.8.1`.
- **docs/development.md** — rewrote the "Project layout" block (it still showed a single `main.go`/`main_test.go`, pre-Cobra-split).

Plus a root-cause fix: **`.releaserc.json`** now lists `docs/usage.md` in the `@semantic-release/git` assets, so its release-time Docker-tag bump is actually committed (otherwise it silently drifts, which is exactly what happened).

## Test Plan

- [x] Docs reviewed line-by-line against `internal/thinking/schema.go`, `cmd/critical-thinking/root.go`, and the actual `cmd/` file set.
- [x] `.releaserc.json` remains valid JSON.
- [x] No code changed — Go build/tests unaffected.

> Note: this touches the same `@semantic-release/git` assets array as #62 (which adds the plugin installer). Whichever merges second needs a one-line reconcile so the array contains both `docs/usage.md` and `plugins/critical-thinking/hooks/install-binary.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)