### PR TITLE
feat: per-episode isolation + input-contract hardening (#32, #65)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ coverage.txt
 
 # Working/agent-only documents (not committed to repo)
 docs/codebase-review.md
+docs/designs/
 docs/plans/
 docs/prompts/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Response (`structuredContent`):
 }
 ```
 
+Pass an optional `episodeId` (any string) to keep independent lines of reasoning
+isolated; reuse it within a problem and switch it for a new one. `sessionConfidence`
+is the mean over the current episode's trunk thoughts.
+
 The `text` content is a rendered transcript in first-person, exploratory voice. Every call must send `thoughtNumber` and `totalThoughts` (both required, ≥ 1); if `thoughtNumber` exceeds `totalThoughts` the server raises `totalThoughts` to match. Keep each field to one tight sentence — the tool description asks for that brevity; the server does not enforce a hard limit. The full contract lives in the tool description itself.
 
 ## Resources

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,25 @@
 
 Cumulative breaking-change log for `critical-thinking`. Most recent changes first.
 
+### Per-episode isolation + self-correcting validation (#32, #65)
+
+Non-breaking, additive.
+
+- **New optional input field `episodeId`** (string). Absent behaves exactly as
+  before (a single `"default"` episode). Tag a stable value per logical problem
+  to isolate independent reasoning; it is echoed back on the response. Up to 64
+  active episodes are retained per connection (LRU); a long-dormant episode
+  beyond that is evicted and restarts fresh on next use (logged at `Warn`) — so
+  an unexpected `thoughtHistoryLength` reset is the cap doing its job, not a bug.
+- **New `hint` field on error results.** Validation failures from the input
+  contract now include `hint` — the full required-field checklist — so callers
+  can self-correct. It appears **only on `Validate()`-path errors**; it is NOT
+  present on the two range errors (`revisesThought`/`branchFromThought` out of
+  range) nor on the SDK's own plain-text missing-property errors. The existing
+  `{error, status:"failed"}` shape is preserved (the field is additive).
+- `sessionConfidence` is now scoped to the current episode rather than the whole
+  connection — trustworthy only when a consistent `episodeId` is reused.
+
 ## Claude Code plugin re-introduced
 
 Non-breaking. A Claude Code **plugin** now ships in-repo under `plugins/critical-thinking/`, bundling the MCP server (auto-installed via a `SessionStart` hook), a two-gate critical-thinking verification skill, and a `UserPromptSubmit` hook that activates the skill on every prompt. This is additive packaging — the server, its `criticalthinking` tool, schema, and transports are unchanged. It reverses the earlier removal of the plugin scaffolding described below, so the note that "the project is now solely an MCP server" no longer holds. See [`plugins/critical-thinking/README.md`](../plugins/critical-thinking/README.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -76,7 +76,8 @@ line) and read the result back.
 - `critical-thinking cli --json` prints structured `ThoughtResponse` as NDJSON —
   the machine-readable surface for programmatic callers.
 
-History, confidence, and branches accumulate across input lines within one run
+History, confidence, and branches accumulate across input lines that share an
+`episodeId` (absent → the `"default"` episode) within one run
 (the analog of a single stdio MCP session). Every line is processed; the command
 exits non-zero if any line fails. A malformed-JSON line is reported on stderr (in
 both modes). A line the engine rejects (for example a validation error) is
@@ -90,6 +91,10 @@ Each `ThoughtData` line must carry the required fields — `thought`,
 `nextStepRationale` when `nextThoughtNeeded` is `true`. See
 [clients.md#cli-no-mcp-host](clients.md#cli-no-mcp-host) for the full
 field-by-field contract.
+
+- `episodeId` (string, optional): partitions state into independent reasoning
+  episodes. Absent → the shared `"default"` episode. Reuse one value per problem;
+  switch for a new problem. Echoed back in the response.
 
 ## A worked session
 

--- a/internal/thinking/contract_test.go
+++ b/internal/thinking/contract_test.go
@@ -68,3 +68,20 @@ func TestRangeErrorOmitsHint(t *testing.T) {
 		t.Errorf("range error must not carry a hint; got %q", p.Hint)
 	}
 }
+
+func TestToolDescriptionContractGuards(t *testing.T) {
+	for _, want := range []string{
+		requiredFieldsChecklist,   // front-loaded checklist (single source)
+		"episodeId",               // isolation discipline is documented
+		"unrelated problem",       // the episodeId switch guidance
+		"current episode's trunk", // corrected per-episode confidence line (substring chosen to survive the line-wrap in the description text)
+	} {
+		if !strings.Contains(ToolDescription, want) {
+			t.Errorf("ToolDescription missing %q", want)
+		}
+	}
+	// The stale connection-wide confidence phrasing must be gone.
+	if strings.Contains(ToolDescription, "(mean of trunk thoughts)") {
+		t.Error("ToolDescription still has the pre-episode confidence phrasing")
+	}
+}

--- a/internal/thinking/contract_test.go
+++ b/internal/thinking/contract_test.go
@@ -1,0 +1,70 @@
+package thinking
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// errorPayload is the JSON shape ProcessThought emits on an error result.
+type errorPayload struct {
+	Error  string `json:"error"`
+	Status string `json:"status"`
+	Hint   string `json:"hint"`
+}
+
+func TestValidatePathErrorCarriesHint(t *testing.T) {
+	s := NewServer()
+	td := validInput(1)
+	td.NextStepRationale = "" // Validate() fails: required when nextThoughtNeeded=true
+	res, err := s.ProcessThought(td)
+	if err != nil {
+		t.Fatalf("unexpected go error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	var p errorPayload
+	if err := json.Unmarshal([]byte(res.Text), &p); err != nil {
+		t.Fatalf("error result is not JSON: %v\n%s", err, res.Text)
+	}
+	if p.Status != "failed" {
+		t.Errorf("status = %q, want failed", p.Status)
+	}
+	if p.Hint != requiredFieldsChecklist {
+		t.Errorf("hint = %q, want the shared checklist", p.Hint)
+	}
+	// The hint must name every required field.
+	for _, f := range []string{
+		"thought", "thoughtNumber", "totalThoughts", "nextThoughtNeeded",
+		"confidence", "assumptions", "critique", "counterArgument", "nextStepRationale",
+	} {
+		if !strings.Contains(p.Hint, f) {
+			t.Errorf("hint missing required field %q: %s", f, p.Hint)
+		}
+	}
+}
+
+func TestRangeErrorOmitsHint(t *testing.T) {
+	s := NewServer()
+	if _, err := s.ProcessThought(validInput(1)); err != nil {
+		t.Fatal(err)
+	}
+	td := validInput(2)
+	td.IsRevision = boolPtr(true)
+	td.RevisesThought = intPtr(99) // out of range -> ProcessThought range error, not Validate()
+	res, err := s.ProcessThought(td)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	var p errorPayload
+	if err := json.Unmarshal([]byte(res.Text), &p); err != nil {
+		t.Fatalf("error result is not JSON: %v", err)
+	}
+	if p.Hint != "" {
+		t.Errorf("range error must not carry a hint; got %q", p.Hint)
+	}
+}

--- a/internal/thinking/description.go
+++ b/internal/thinking/description.go
@@ -25,6 +25,16 @@ fuses three disciplines:
 Sequential thinking is the *spine*. Thinking out loud is the *voice*. Critical
 self-examination is the *check*. Skipping any one of them is a misuse.
 
+Required fields — ` + requiredFieldsChecklist + `
+
+Isolating episodes:
+  - Tag each independent line of reasoning with a stable episodeId (any string).
+    Reuse the same episodeId for every thought in one problem; switch to a new
+    one when you start an unrelated problem. Omitting it routes to a shared
+    "default" episode — fine for a single line of reasoning, but parallel
+    subagents or unrelated problems then contaminate each other's history and
+    confidence. episodeId is echoed back so you can confirm routing.
+
 How a session unfolds:
 
   - You start at thoughtNumber=1 with an estimated totalThoughts. Each call
@@ -80,7 +90,8 @@ Anti-patterns to avoid:
 
 What you get back:
   - A narrated transcript of this thought (first-person, exploratory voice).
-  - Running session confidence (mean of trunk thoughts).
+  - Running session confidence — the mean over the current episode's trunk
+    thoughts. Trustworthy only when you reuse a consistent episodeId.
   - Per-branch confidence (if any branches exist).
   - The full state needed to plan the next call.
 

--- a/internal/thinking/episode_test.go
+++ b/internal/thinking/episode_test.go
@@ -1,0 +1,266 @@
+package thinking
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// episodeResp runs one thought and returns the decoded structured response.
+func episodeResp(t *testing.T, s *SequentialThinkingServer, td ThoughtData) ThoughtResponse {
+	t.Helper()
+	res, err := s.ProcessThought(td)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected IsError=true, text=%s", res.Text)
+	}
+	var resp ThoughtResponse
+	if err := json.Unmarshal([]byte(res.StructuredJSON), &resp); err != nil {
+		t.Fatalf("unmarshal structured: %v", err)
+	}
+	return resp
+}
+
+func TestResponseEchoesEpisodeID(t *testing.T) {
+	s := NewServer()
+
+	td := validInput(1)
+	td.EpisodeID = "alpha"
+	resp := episodeResp(t, s, td)
+	if resp.EpisodeID != "alpha" {
+		t.Errorf("EpisodeID = %q, want %q", resp.EpisodeID, "alpha")
+	}
+
+	td2 := validInput(1)
+	// EpisodeID left empty.
+	resp2 := episodeResp(t, s, td2)
+	if resp2.EpisodeID != "default" {
+		t.Errorf("absent episodeId echoed as %q, want %q", resp2.EpisodeID, "default")
+	}
+}
+
+func TestEpisodesAreIsolated(t *testing.T) {
+	s := NewServer()
+
+	// Episode alpha: two trunk thoughts at confidence 0.2.
+	for i := range 2 {
+		td := validInput(i + 1)
+		td.EpisodeID = "alpha"
+		td.Confidence = 0.2
+		episodeResp(t, s, td)
+	}
+
+	// Episode beta: one trunk thought at confidence 0.8, plus a branch.
+	tdB := validInput(1)
+	tdB.EpisodeID = "beta"
+	tdB.Confidence = 0.8
+	respB := episodeResp(t, s, tdB)
+	if respB.ThoughtHistoryLength != 1 {
+		t.Errorf("beta history length = %d, want 1 (not shared with alpha)", respB.ThoughtHistoryLength)
+	}
+
+	tdBranch := validInput(2)
+	tdBranch.EpisodeID = "beta"
+	tdBranch.BranchFromThought = intPtr(1)
+	tdBranch.BranchID = "beta-branch"
+	tdBranch.Confidence = 0.8
+	respBranch := episodeResp(t, s, tdBranch)
+	if len(respBranch.Branches) != 1 || respBranch.Branches[0] != "beta-branch" {
+		t.Errorf("beta branches = %v, want [beta-branch]", respBranch.Branches)
+	}
+
+	// Now run a third alpha thought and confirm alpha's view is unaffected by beta.
+	tdA := validInput(3)
+	tdA.EpisodeID = "alpha"
+	tdA.Confidence = 0.2
+	respA := episodeResp(t, s, tdA)
+	if respA.ThoughtHistoryLength != 3 {
+		t.Errorf("alpha history length = %d, want 3", respA.ThoughtHistoryLength)
+	}
+	if !almostEqual(respA.SessionConfidence, 0.2) {
+		t.Errorf("alpha sessionConfidence = %v, want 0.2 (beta's 0.8 must not leak)", respA.SessionConfidence)
+	}
+	if len(respA.Branches) != 0 {
+		t.Errorf("alpha branches = %v, want [] (beta's branch must not leak)", respA.Branches)
+	}
+}
+
+func TestDefaultEpisodeWhenAbsent(t *testing.T) {
+	s := NewServer()
+
+	// A thought with no episodeId and a thought with episodeId:"default" must
+	// land in the same episode.
+	resp1 := episodeResp(t, s, validInput(1))
+	if resp1.ThoughtHistoryLength != 1 {
+		t.Errorf("first default thought length = %d, want 1", resp1.ThoughtHistoryLength)
+	}
+
+	td := validInput(2)
+	td.EpisodeID = "default"
+	resp2 := episodeResp(t, s, td)
+	if resp2.ThoughtHistoryLength != 2 {
+		t.Errorf("explicit default thought length = %d, want 2 (same episode as absent)", resp2.ThoughtHistoryLength)
+	}
+	if got := s.HistoryLength(); got != 2 {
+		t.Errorf("HistoryLength() = %d, want 2 (reads default episode)", got)
+	}
+}
+
+func TestRevisePerEpisodeValidation(t *testing.T) {
+	s := NewServer()
+
+	// Episode alpha has 2 thoughts; episode beta has 0.
+	for i := range 2 {
+		td := validInput(i + 1)
+		td.EpisodeID = "alpha"
+		episodeResp(t, s, td)
+	}
+
+	// Revising thought 2 in alpha is in range.
+	tdA := validInput(3)
+	tdA.EpisodeID = "alpha"
+	tdA.IsRevision = boolPtr(true)
+	tdA.RevisesThought = intPtr(2)
+	if resp, err := s.ProcessThought(tdA); err != nil {
+		t.Fatal(err)
+	} else if resp.IsError {
+		t.Errorf("revising thought 2 in alpha should be in range; got error: %s", resp.Text)
+	}
+
+	// Revising thought 2 in beta (empty) is out of range — must validate against
+	// beta's history (length 0), not alpha's or the server's.
+	tdB := validInput(1)
+	tdB.EpisodeID = "beta"
+	tdB.IsRevision = boolPtr(true)
+	tdB.RevisesThought = intPtr(2)
+	res, err := s.ProcessThought(tdB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("revising thought 2 in empty beta should be out of range")
+	}
+	if !strings.Contains(res.Text, "revisesThought 2 out of range (history length 0)") {
+		t.Errorf("error message should reference beta's length 0; got: %s", res.Text)
+	}
+}
+
+func TestBranchFromPerEpisodeValidation(t *testing.T) {
+	s := NewServer()
+
+	// Episode alpha has 1 thought.
+	tdSeed := validInput(1)
+	tdSeed.EpisodeID = "alpha"
+	episodeResp(t, s, tdSeed)
+
+	// Branch from thought 1 in beta (empty) is out of range against beta.
+	tdB := validInput(1)
+	tdB.EpisodeID = "beta"
+	tdB.BranchFromThought = intPtr(1)
+	tdB.BranchID = "beta-branch"
+	res, err := s.ProcessThought(tdB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Error("branchFromThought 1 in empty beta should be out of range")
+	}
+	if !strings.Contains(res.Text, "branchFromThought 1 out of range (history length 0)") {
+		t.Errorf("error message should reference beta's length 0; got: %s", res.Text)
+	}
+}
+
+// episodeHistoryLen reads the trunk length of a named episode without mutating
+// LRU order. Test-only helper; reaches into unexported state under the lock.
+func episodeHistoryLen(s *SequentialThinkingServer, id string) (int, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ep, ok := s.episodes[id]
+	if !ok {
+		return 0, false
+	}
+	return len(ep.thoughtHistory), true
+}
+
+func TestEpisodeLRUEviction(t *testing.T) {
+	s := newServerWithMax(2)
+
+	// Create episodes a and b.
+	for _, id := range []string{"a", "b"} {
+		td := validInput(1)
+		td.EpisodeID = id
+		episodeResp(t, s, td)
+	}
+
+	// Touch a so b becomes least-recently-used.
+	tdA := validInput(2)
+	tdA.EpisodeID = "a"
+	episodeResp(t, s, tdA)
+
+	// Create c — this exceeds the cap of 2 and must evict the LRU episode (b).
+	tdC := validInput(1)
+	tdC.EpisodeID = "c"
+	episodeResp(t, s, tdC)
+
+	if _, ok := episodeHistoryLen(s, "b"); ok {
+		t.Error("episode b should have been evicted as least-recently-used")
+	}
+	if got, ok := episodeHistoryLen(s, "a"); !ok || got != 2 {
+		t.Errorf("episode a should retain its history (len 2); got len=%d ok=%v", got, ok)
+	}
+
+	// Reusing b restarts it at length 1 (fresh episode).
+	tdB := validInput(1)
+	tdB.EpisodeID = "b"
+	respB := episodeResp(t, s, tdB)
+	if respB.ThoughtHistoryLength != 1 {
+		t.Errorf("re-created episode b should restart at length 1; got %d", respB.ThoughtHistoryLength)
+	}
+}
+
+func TestParallelEpisodesIsolation(t *testing.T) {
+	// N distinct episodes (<= defaultMaxEpisodes so none are evicted), each
+	// submitting M thoughts concurrently. Every episode must end with exactly M
+	// thoughts — never N*M — proving cross-episode isolation under concurrency.
+	const n = 16
+	const m = 25
+
+	s := NewServer()
+
+	var wg sync.WaitGroup
+	finalLen := make([]int, n)
+	for g := range n {
+		wg.Go(func() {
+			id := "episode-" + strconv.Itoa(g)
+			last := 0
+			for i := range m {
+				td := validInput(i + 1)
+				td.TotalThoughts = m
+				td.EpisodeID = id
+				res, err := s.ProcessThought(td)
+				if err != nil || res.IsError {
+					t.Errorf("episode %s thought %d: err=%v isError=%v text=%s", id, i+1, err, res.IsError, res.Text)
+					return
+				}
+				var resp ThoughtResponse
+				if err := json.Unmarshal([]byte(res.StructuredJSON), &resp); err != nil {
+					t.Errorf("episode %s unmarshal: %v", id, err)
+					return
+				}
+				last = resp.ThoughtHistoryLength
+			}
+			finalLen[g] = last
+		})
+	}
+	wg.Wait()
+
+	for g, got := range finalLen {
+		if got != m {
+			t.Errorf("episode %d final thoughtHistoryLength = %d, want %d", g, got, m)
+		}
+	}
+}

--- a/internal/thinking/schema.go
+++ b/internal/thinking/schema.go
@@ -50,6 +50,13 @@ type ThoughtResponse struct {
 	EpisodeID string `json:"episodeId"`
 }
 
+// requiredFieldsChecklist is the one-line input-contract summary, shared by the
+// tool description's lead-in (description.go) and the validation-error hint
+// (server.go) so the two cannot drift. It is the single source of truth for the
+// required-field set; a change here updates both consumers. (DRY: one piece of
+// knowledge — what every call must send — one representation.)
+const requiredFieldsChecklist = "Every call requires: thought, thoughtNumber, totalThoughts, nextThoughtNeeded, confidence, assumptions, critique, counterArgument — plus nextStepRationale whenever nextThoughtNeeded=true."
+
 // Validate enforces every wire-format rule for ThoughtData except those that
 // require knowing the current session state (RevisesThought / BranchFromThought
 // range checks). Those run separately in SequentialThinkingServer.ProcessThought.

--- a/internal/thinking/schema.go
+++ b/internal/thinking/schema.go
@@ -29,6 +29,11 @@ type ThoughtData struct {
 	Critique          string   `json:"critique"`
 	CounterArgument   string   `json:"counterArgument"`
 	NextStepRationale string   `json:"nextStepRationale,omitempty"`
+
+	// EpisodeID partitions state into independent logical reasoning episodes
+	// within one transport session. Empty means the "default" episode.
+	// Any string is valid, so it is not checked in Validate().
+	EpisodeID string `json:"episodeId,omitempty"`
 }
 
 // ThoughtResponse is the structuredContent of a criticalthinking tool call.
@@ -40,6 +45,9 @@ type ThoughtResponse struct {
 	ThoughtHistoryLength int                `json:"thoughtHistoryLength"`
 	SessionConfidence    float64            `json:"sessionConfidence"`
 	BranchConfidences    map[string]float64 `json:"branchConfidences,omitempty"`
+	// EpisodeID echoes the resolved episode ("default" when none was sent) so
+	// the caller can confirm which episode this thought was routed to.
+	EpisodeID string `json:"episodeId"`
 }
 
 // Validate enforces every wire-format rule for ThoughtData except those that

--- a/internal/thinking/server.go
+++ b/internal/thinking/server.go
@@ -178,7 +178,7 @@ type ToolResult struct {
 // returned); validation failures produce IsError=true results.
 func (s *SequentialThinkingServer) ProcessThought(td ThoughtData) (ToolResult, error) {
 	if err := td.Validate(); err != nil {
-		return errorResult(err), nil
+		return validationErrorResult(err), nil
 	}
 
 	// Resolve the logical episode. Empty means the "default" episode. This is
@@ -347,6 +347,20 @@ func (e *episode) renderFooter(b *strings.Builder, td ThoughtData, sessionConf f
 	}
 	fmt.Fprintf(b, "— session confidence %.2f across %d %s",
 		sessionConf, e.confidenceN, noun)
+}
+
+// validationErrorResult formats a contract-validation failure like errorResult
+// but adds a self-correcting `hint` listing every required field, so the caller
+// can fix the next call without a second rejection. Used ONLY for Validate()
+// failures — not for the state-dependent range errors, where a field checklist
+// would be misleading noise.
+func validationErrorResult(err error) ToolResult {
+	body, _ := json.Marshal(struct {
+		Error  string `json:"error"`
+		Status string `json:"status"`
+		Hint   string `json:"hint"`
+	}{Error: err.Error(), Status: "failed", Hint: requiredFieldsChecklist})
+	return ToolResult{Text: string(body), IsError: true}
 }
 
 // errorResult formats a validation/runtime error in the JS-compatible

--- a/internal/thinking/server.go
+++ b/internal/thinking/server.go
@@ -1,13 +1,42 @@
 package thinking
 
 import (
+	"container/list"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync"
 	"time"
 )
+
+// defaultMaxEpisodes bounds the number of logical episodes retained per server.
+// The least-recently-used episode is evicted when a new episode exceeds it.
+const defaultMaxEpisodes = 64
+
+// episode holds the state of one logical reasoning episode. The fields were
+// previously flat on SequentialThinkingServer; they now live per-episode so
+// independent reasoning episodes within one transport session do not
+// contaminate each other's history, confidence, or branches.
+type episode struct {
+	thoughtHistory []ThoughtData
+	branches       map[string][]ThoughtData
+	confidenceSum  float64
+	confidenceN    int
+	branchConfSum  map[string]float64
+	branchConfN    map[string]int
+	lastAccessed   time.Time
+}
+
+func newEpisode() *episode {
+	return &episode{
+		branches:      make(map[string][]ThoughtData),
+		branchConfSum: make(map[string]float64),
+		branchConfN:   make(map[string]int),
+		lastAccessed:  time.Now(),
+	}
+}
 
 // SequentialThinkingServer holds the per-session state for one client of the
 // criticalthinking tool. Construct exactly one per session: in HTTP mode this
@@ -18,51 +47,120 @@ import (
 // is intentionally no map keyed by session-id anywhere — the closure scope is
 // the only addressable path to a session's state.
 type SequentialThinkingServer struct {
-	mu             sync.Mutex
-	thoughtHistory []ThoughtData
-	branches       map[string][]ThoughtData
-	confidenceSum  float64
-	confidenceN    int
-	branchConfSum  map[string]float64
-	branchConfN    map[string]int
-	lastAccessed   time.Time
+	mu sync.Mutex
+	// episodes partitions state by a client-supplied episodeId tool argument.
+	//
+	// Compatible divergence from the rubber-ducky design: this map is keyed by
+	// a CLIENT-SUPPLIED TOOL ARGUMENT (episodeId), scoped WITHIN this single
+	// transport session's closure — NOT by mcp-session-id. One connection still
+	// cannot address another connection's state, so the cross-session isolation
+	// invariant (TestCrossSessionIsolation) is untouched.
+	episodes    map[string]*episode
+	lru         *list.List               // front = most-recently-used; Value = episodeId string
+	lruIndex    map[string]*list.Element // episodeId -> its lru element
+	maxEpisodes int
 }
 
-// NewServer returns an empty SequentialThinkingServer.
+// NewServer returns an empty SequentialThinkingServer bounded to
+// defaultMaxEpisodes logical episodes.
 func NewServer() *SequentialThinkingServer {
+	return newServerWithMax(defaultMaxEpisodes)
+}
+
+// newServerWithMax returns an empty server with a custom episode cap. Tests use
+// a small cap to exercise LRU eviction deterministically.
+func newServerWithMax(max int) *SequentialThinkingServer {
 	return &SequentialThinkingServer{
-		branches:      make(map[string][]ThoughtData),
-		branchConfSum: make(map[string]float64),
-		branchConfN:   make(map[string]int),
-		lastAccessed:  time.Now(),
+		episodes:    make(map[string]*episode),
+		lru:         list.New(),
+		lruIndex:    make(map[string]*list.Element),
+		maxEpisodes: max,
 	}
 }
 
-// HistoryLength returns the number of thoughts in the trunk + branches
-// (a single append-only log).
+// getOrCreateEpisodeLocked returns the episode for id, creating it if absent.
+// Every access (found or created) marks the episode most-recently-used so
+// active episodes are not evicted. Creating a new episode that pushes the count
+// over maxEpisodes evicts the least-recently-used episode. Caller holds s.mu.
+func (s *SequentialThinkingServer) getOrCreateEpisodeLocked(id string) *episode {
+	if elem, ok := s.lruIndex[id]; ok {
+		s.lru.MoveToFront(elem)
+		return s.episodes[id]
+	}
+
+	ep := newEpisode()
+	s.episodes[id] = ep
+	s.lruIndex[id] = s.lru.PushFront(id)
+
+	if len(s.episodes) > s.maxEpisodes {
+		s.evictLRULocked()
+	}
+	return ep
+}
+
+// evictLRULocked removes the least-recently-used episode (the lru back element).
+// Caller holds s.mu.
+func (s *SequentialThinkingServer) evictLRULocked() {
+	back := s.lru.Back()
+	if back == nil {
+		return
+	}
+	evictedKey := back.Value.(string)
+	evictedLen := len(s.episodes[evictedKey].thoughtHistory)
+
+	s.lru.Remove(back)
+	delete(s.episodes, evictedKey)
+	delete(s.lruIndex, evictedKey)
+
+	slog.Warn("evicted least-recently-used thinking episode",
+		"episodeId", evictedKey,
+		"thoughtHistoryLength", evictedLen,
+		"maxEpisodes", s.maxEpisodes)
+}
+
+// defaultEpisodeLocked returns the "default" episode without creating it or
+// touching the LRU order, so informational accessors stay side-effect-free.
+// Returns nil when the default episode does not exist yet. Caller holds s.mu.
+func (s *SequentialThinkingServer) defaultEpisodeLocked() *episode {
+	return s.episodes["default"]
+}
+
+// HistoryLength returns the number of thoughts in the default episode's trunk +
+// branches (a single append-only log). Side-effect-free read.
 func (s *SequentialThinkingServer) HistoryLength() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return len(s.thoughtHistory)
+	ep := s.defaultEpisodeLocked()
+	if ep == nil {
+		return 0
+	}
+	return len(ep.thoughtHistory)
 }
 
-// SessionConfidence returns the running mean confidence over trunk thoughts.
-// Returns 0 when no trunk thoughts have been recorded.
+// SessionConfidence returns the running mean confidence over the default
+// episode's trunk thoughts. Returns 0 when no trunk thoughts have been
+// recorded. Side-effect-free read.
 func (s *SequentialThinkingServer) SessionConfidence() float64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.confidenceN == 0 {
+	ep := s.defaultEpisodeLocked()
+	if ep == nil || ep.confidenceN == 0 {
 		return 0
 	}
-	return s.confidenceSum / float64(s.confidenceN)
+	return ep.confidenceSum / float64(ep.confidenceN)
 }
 
-// LastAccessed returns the time of the last successful ProcessThought call.
-// Used by the HTTP idle-timeout cleanup goroutine in main.go.
+// LastAccessed returns the time of the last successful ProcessThought call on
+// the default episode. Informational only — HTTP idle-session lifecycle is
+// driven by the SDK's SessionTimeout, not by this value. Side-effect-free read.
 func (s *SequentialThinkingServer) LastAccessed() time.Time {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.lastAccessed
+	ep := s.defaultEpisodeLocked()
+	if ep == nil {
+		return time.Time{}
+	}
+	return ep.lastAccessed
 }
 
 // ToolResult is the package-internal return type from ProcessThought. main.go
@@ -83,60 +181,70 @@ func (s *SequentialThinkingServer) ProcessThought(td ThoughtData) (ToolResult, e
 		return errorResult(err), nil
 	}
 
+	// Resolve the logical episode. Empty means the "default" episode. This is
+	// done here, not in Validate(), so Validate() stays state-free.
+	episodeID := td.EpisodeID
+	if episodeID == "" {
+		episodeID = "default"
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Cross-field validation against state.
-	if td.RevisesThought != nil && *td.RevisesThought > len(s.thoughtHistory) {
+	ep := s.getOrCreateEpisodeLocked(episodeID)
+
+	// Cross-field validation against the EPISODE's state.
+	if td.RevisesThought != nil && *td.RevisesThought > len(ep.thoughtHistory) {
 		return errorResult(fmt.Errorf("revisesThought %d out of range (history length %d)",
-			*td.RevisesThought, len(s.thoughtHistory))), nil
+			*td.RevisesThought, len(ep.thoughtHistory))), nil
 	}
-	if td.BranchFromThought != nil && *td.BranchFromThought > len(s.thoughtHistory) {
+	if td.BranchFromThought != nil && *td.BranchFromThought > len(ep.thoughtHistory) {
 		return errorResult(fmt.Errorf("branchFromThought %d out of range (history length %d)",
-			*td.BranchFromThought, len(s.thoughtHistory))), nil
+			*td.BranchFromThought, len(ep.thoughtHistory))), nil
 	}
 
 	if td.ThoughtNumber > td.TotalThoughts {
 		td.TotalThoughts = td.ThoughtNumber
 	}
 
-	s.thoughtHistory = append(s.thoughtHistory, td)
-	s.lastAccessed = time.Now()
+	ep.thoughtHistory = append(ep.thoughtHistory, td)
+	ep.lastAccessed = time.Now()
 
 	if td.BranchFromThought != nil && td.BranchID != "" {
-		s.branches[td.BranchID] = append(s.branches[td.BranchID], td)
+		ep.branches[td.BranchID] = append(ep.branches[td.BranchID], td)
 	}
 
 	onBranch := td.BranchFromThought != nil && td.BranchID != ""
 	if onBranch {
-		s.branchConfSum[td.BranchID] += td.Confidence
-		s.branchConfN[td.BranchID]++
+		ep.branchConfSum[td.BranchID] += td.Confidence
+		ep.branchConfN[td.BranchID]++
 	} else {
-		s.confidenceSum += td.Confidence
-		s.confidenceN++
+		ep.confidenceSum += td.Confidence
+		ep.confidenceN++
 	}
 
 	var branchConf map[string]float64
-	if len(s.branchConfN) > 0 {
-		branchConf = make(map[string]float64, len(s.branchConfN))
-		for k, n := range s.branchConfN {
-			branchConf[k] = s.branchConfSum[k] / float64(n)
+	if len(ep.branchConfN) > 0 {
+		branchConf = make(map[string]float64, len(ep.branchConfN))
+		for k, n := range ep.branchConfN {
+			branchConf[k] = ep.branchConfSum[k] / float64(n)
 		}
 	}
 
 	sessionConf := 0.0
-	if s.confidenceN > 0 {
-		sessionConf = s.confidenceSum / float64(s.confidenceN)
+	if ep.confidenceN > 0 {
+		sessionConf = ep.confidenceSum / float64(ep.confidenceN)
 	}
 
 	resp := ThoughtResponse{
 		ThoughtNumber:        td.ThoughtNumber,
 		TotalThoughts:        td.TotalThoughts,
 		NextThoughtNeeded:    *td.NextThoughtNeeded,
-		Branches:             sortedKeys(s.branches),
-		ThoughtHistoryLength: len(s.thoughtHistory),
+		Branches:             sortedKeys(ep.branches),
+		ThoughtHistoryLength: len(ep.thoughtHistory),
 		SessionConfidence:    sessionConf,
 		BranchConfidences:    branchConf,
+		EpisodeID:            episodeID,
 	}
 
 	structured, err := json.Marshal(resp)
@@ -146,18 +254,18 @@ func (s *SequentialThinkingServer) ProcessThought(td ThoughtData) (ToolResult, e
 	}
 
 	return ToolResult{
-		Text:           s.renderTranscriptLocked(td, sessionConf),
+		Text:           ep.renderTranscript(td, sessionConf),
 		StructuredJSON: string(structured),
 		IsError:        false,
 	}, nil
 }
 
-// renderTranscriptLocked builds the narrated transcript text for one thought.
-// Caller must hold s.mu.
-func (s *SequentialThinkingServer) renderTranscriptLocked(td ThoughtData, sessionConf float64) string {
+// renderTranscript builds the narrated transcript text for one thought.
+// Caller must hold s.mu (the episode is reached only through the locked server).
+func (e *episode) renderTranscript(td ThoughtData, sessionConf float64) string {
 	var b strings.Builder
 
-	header := s.headerLineLocked(td)
+	header := e.headerLine(td)
 	fmt.Fprintf(&b, "%s\n\n", header)
 	fmt.Fprintln(&b, td.Thought)
 	fmt.Fprintln(&b)
@@ -182,21 +290,21 @@ func (s *SequentialThinkingServer) renderTranscriptLocked(td ThoughtData, sessio
 		fmt.Fprintf(&b, "  Next, I want to: %s\n\n", td.NextStepRationale)
 	}
 
-	s.renderFooterLocked(&b, td, sessionConf)
+	e.renderFooter(&b, td, sessionConf)
 	return b.String()
 }
 
-// headerLineLocked picks one of four header forms based on revision/branch state.
+// headerLine picks one of four header forms based on revision/branch state.
 // Caller must hold s.mu.
-func (s *SequentialThinkingServer) headerLineLocked(td ThoughtData) string {
+func (e *episode) headerLine(td ThoughtData) string {
 	switch {
 	case td.IsRevision != nil && *td.IsRevision && td.RevisesThought != nil:
 		return fmt.Sprintf("Revision of thought %d (now thought %d) · confidence %.2f",
 			*td.RevisesThought, td.ThoughtNumber, td.Confidence)
 	case td.BranchFromThought != nil && td.BranchID != "":
 		// First-in-branch vs subsequent: count the current branch's depth.
-		// At this point the new thought has already been appended to s.branches[BranchID].
-		depth := len(s.branches[td.BranchID])
+		// At this point the new thought has already been appended to e.branches[BranchID].
+		depth := len(e.branches[td.BranchID])
 		if depth <= 1 {
 			return fmt.Sprintf("Branch '%s' from thought %d · confidence %.2f",
 				td.BranchID, *td.BranchFromThought, td.Confidence)
@@ -209,15 +317,15 @@ func (s *SequentialThinkingServer) headerLineLocked(td ThoughtData) string {
 	}
 }
 
-// renderFooterLocked writes either the trunk or branch+trunk footer.
+// renderFooter writes either the trunk or branch+trunk footer.
 // Caller must hold s.mu.
-func (s *SequentialThinkingServer) renderFooterLocked(b *strings.Builder, td ThoughtData, sessionConf float64) {
+func (e *episode) renderFooter(b *strings.Builder, td ThoughtData, sessionConf float64) {
 	onBranch := td.BranchFromThought != nil && td.BranchID != ""
 	if onBranch {
-		bn := s.branchConfN[td.BranchID]
+		bn := e.branchConfN[td.BranchID]
 		bc := 0.0
 		if bn > 0 {
-			bc = s.branchConfSum[td.BranchID] / float64(bn)
+			bc = e.branchConfSum[td.BranchID] / float64(bn)
 		}
 		bnoun := "thought"
 		if bn != 1 {
@@ -226,19 +334,19 @@ func (s *SequentialThinkingServer) renderFooterLocked(b *strings.Builder, td Tho
 		fmt.Fprintf(b, "— branch '%s' confidence %.2f across %d %s\n",
 			td.BranchID, bc, bn, bnoun)
 		tnoun := "thought"
-		if s.confidenceN != 1 {
+		if e.confidenceN != 1 {
 			tnoun = "thoughts"
 		}
 		fmt.Fprintf(b, "— session confidence (trunk) %.2f across %d %s",
-			sessionConf, s.confidenceN, tnoun)
+			sessionConf, e.confidenceN, tnoun)
 		return
 	}
 	noun := "thought"
-	if s.confidenceN != 1 {
+	if e.confidenceN != 1 {
 		noun = "thoughts"
 	}
 	fmt.Fprintf(b, "— session confidence %.2f across %d %s",
-		sessionConf, s.confidenceN, noun)
+		sessionConf, e.confidenceN, noun)
 }
 
 // errorResult formats a validation/runtime error in the JS-compatible
@@ -270,17 +378,26 @@ type HistorySnapshot struct {
 
 // Snapshot returns the current state for the thinking://current resource.
 // The returned slices and map are safe to mutate without affecting the server.
+//
+// The resource intentionally exposes only the "default" episode: surfacing
+// per-episode state through this resource would risk the same cross-exposure
+// the resource handler already guards against. Side-effect-free read.
 func (s *SequentialThinkingServer) Snapshot() HistorySnapshot {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	thoughts := make([]ThoughtData, len(s.thoughtHistory))
-	copy(thoughts, s.thoughtHistory)
+	ep := s.defaultEpisodeLocked()
+	if ep == nil {
+		return HistorySnapshot{Thoughts: []ThoughtData{}}
+	}
+
+	thoughts := make([]ThoughtData, len(ep.thoughtHistory))
+	copy(thoughts, ep.thoughtHistory)
 
 	var branches map[string][]ThoughtData
-	if len(s.branches) > 0 {
-		branches = make(map[string][]ThoughtData, len(s.branches))
-		for k, v := range s.branches {
+	if len(ep.branches) > 0 {
+		branches = make(map[string][]ThoughtData, len(ep.branches))
+		for k, v := range ep.branches {
 			cp := make([]ThoughtData, len(v))
 			copy(cp, v)
 			branches[k] = cp

--- a/plugins/critical-thinking/skills/critical-thinking/SKILL.md
+++ b/plugins/critical-thinking/skills/critical-thinking/SKILL.md
@@ -51,6 +51,18 @@ Between the two gates, continue to use extended thinking for any non-trivial rea
 
 ---
 
+## Isolate each task with a stable episodeId
+
+Pass a stable `episodeId` (any string — e.g. a short slug for the current task)
+and **reuse it for both gates of the same prompt**. This keeps a task's intent
+and result verification together and isolated from other tasks, other prompts,
+and other projects sharing the same MCP connection. Without it, every call lands
+in one shared "default" episode and `sessionConfidence` / history are averaged
+across unrelated reasoning. Start a new `episodeId` when you move to an
+unrelated task.
+
+---
+
 ## Tool Failure Protocol
 
 **If `criticalthinking` is unavailable at any point — HALT IMMEDIATELY.**


### PR DESCRIPTION
Resolves two issues on one branch — they converge on the same model-facing contract.

## #32 — Per-episode isolation
State was isolated only per transport connection, so a long-lived or **gateway-multiplexed** connection accumulated unrelated thoughts into one shared history. A local-transcript scan confirmed the ToolHive gateway funnels every project on a machine through one connection: a brand-new episode's first thought saw `thoughtHistoryLength` ~1000 and a `sessionConfidence` averaged over ~1000 unrelated thoughts (reproduced live during development).

- Optional `episodeId` input partitions thought state into independent episodes within one connection (absent → `"default"`, fully backward compatible); echoed back on the response.
- Flat server fields refactored into an `episode` struct held in `map[episodeId]*episode` behind the existing mutex; render helpers became `*episode` methods.
- `revisesThought`/`branchFromThought` now validated **against the episode**, not the whole connection.
- Generous LRU cap (64 episodes/connection) bounds memory on **both** transports (stdio has no idle timeout); evictions logged at `Warn`; a re-touched evicted episode restarts fresh.
- Tool description + skill instruct the model to tag a stable `episodeId` per problem (the core is inert until the model does this — these doc commits are load-bearing, not cosmetic).

**Compatible divergence** from the rubber-ducky "no session-id map" rule: the map keys on a client-supplied tool argument within one transport session's closure, **not** on `mcp-session-id`, so cross-session isolation is untouched (`TestCrossSessionIsolation` unchanged + green).

## #65 — Input-validation friction
A scan found ~14% of `criticalthinking` calls failed input validation, 64% on the conditionally-required `nextStepRationale`.

- New self-correcting `hint` field on `Validate()`-path errors carries the full required-field checklist so callers self-correct. Additive — `{error, status:"failed"}` shape preserved; **not** present on the two range errors or the SDK's plain-text missing-property errors.
- Tool description front-loads the same checklist (so models front-load the contract instead of learning by rejection).
- The checklist is **one shared constant** feeding both the hint and the description (DRY).

## Validation & review
- Direction validated cold (qualified-yes), plan reviewed against design, and a fresh independent full-diff review — all 7 acceptance criteria pass, no Critical/Important issues.
- `nextStepRationale` deliberately kept conditional (discipline preserved); friction fixed via the checklist + hint.

## Test plan
- [x] `go test ./... -race -count=1` — green
- [x] `go vet ./...`, `gofmt -l` — clean
- [x] Backward compat: absent `episodeId` behaves as before; `TestProcessThoughtValidationError`, `TestCrossSessionIsolation`, `cli_test` substring asserts unchanged + pass
- [x] New regression tests: episode isolation, parallel-episode under `-race`, LRU eviction, per-episode revise/branch validation, hint scoping, description contract guards

Closes #32
Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)