### PR TITLE
feat!: remove --json flag from cli subcommand

### DIFF
--- a/cmd/critical-thinking/cli.go
+++ b/cmd/critical-thinking/cli.go
@@ -23,8 +23,11 @@ var errCLIFailed = errors.New("cli: one or more input lines failed")
 // One in-memory thinking.NewServer() lives for the call, so history,
 // confidence, and branches accumulate across input lines — the analog of a
 // stdio MCP session. Input is NDJSON: one ThoughtData per non-blank line.
-// Returns 0 if every line succeeded, 1 if any line errored.
-func runCLI(stdin io.Reader, stdout, stderr io.Writer, jsonOut bool) int {
+// Output is NDJSON too: one structured ThoughtResponse per processed line. A
+// line the engine rejects emits its error JSON to stdout so the stream stays
+// line-aligned; malformed-JSON lines are diagnosed on stderr only. Returns 0
+// if every line succeeded, 1 if any line errored.
+func runCLI(stdin io.Reader, stdout, stderr io.Writer) int {
 	state := thinking.NewServer()
 	sc := bufio.NewScanner(stdin)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // tolerate long thoughts
@@ -52,18 +55,10 @@ func runCLI(stdin io.Reader, stdout, stderr io.Writer, jsonOut bool) int {
 		}
 		if res.IsError {
 			failed = true
-			if jsonOut {
-				_, _ = fmt.Fprintln(stdout, res.Text) // error JSON keeps NDJSON aligned
-			} else {
-				_, _ = fmt.Fprintln(stderr, res.Text)
-			}
+			_, _ = fmt.Fprintln(stdout, res.Text) // error JSON keeps NDJSON aligned
 			continue
 		}
-		if jsonOut {
-			_, _ = fmt.Fprintln(stdout, res.StructuredJSON)
-		} else {
-			_, _ = fmt.Fprintf(stdout, "%s\n\n", res.Text)
-		}
+		_, _ = fmt.Fprintln(stdout, res.StructuredJSON)
 	}
 	if err := sc.Err(); err != nil {
 		_, _ = fmt.Fprintf(stderr, "cli: read: %v\n", err)
@@ -75,24 +70,21 @@ func runCLI(stdin io.Reader, stdout, stderr io.Writer, jsonOut bool) int {
 	return 0
 }
 
-// newCliCmd streams NDJSON ThoughtData from stdin through the engine (no MCP).
-// --json emits structured ThoughtResponse NDJSON instead of the transcript.
-// It processes EVERY line, then returns errCLIFailed iff any line failed, so
-// the exit code is 1 without fail-fast (pin 1).
+// newCliCmd streams NDJSON ThoughtData from stdin through the engine (no MCP),
+// emitting one structured ThoughtResponse JSON object per line. It processes
+// EVERY line, then returns errCLIFailed iff any line failed, so the exit code
+// is 1 without fail-fast (pin 1).
 func newCliCmd() *cobra.Command {
-	var jsonOut bool
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use:   "cli",
 		Short: "Stream NDJSON ThoughtData through the engine (no MCP host)",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			code := runCLI(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr(), jsonOut)
+			code := runCLI(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
 			if code != 0 {
 				return errCLIFailed
 			}
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit structured ThoughtResponse as NDJSON instead of the transcript")
-	return cmd
 }

--- a/cmd/critical-thinking/cli_test.go
+++ b/cmd/critical-thinking/cli_test.go
@@ -13,7 +13,7 @@ import (
 func TestRunCLIJSONOutput(t *testing.T) {
 	in := `{"thought":"x","thoughtNumber":1,"totalThoughts":1,"nextThoughtNeeded":false,"confidence":0.5,"assumptions":[],"critique":"c","counterArgument":"ca"}` + "\n"
 	var out, errb bytes.Buffer
-	code := runCLI(strings.NewReader(in), &out, &errb, true)
+	code := runCLI(strings.NewReader(in), &out, &errb)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr = %s", code, errb.String())
 	}
@@ -26,23 +26,30 @@ func TestRunCLIJSONOutput(t *testing.T) {
 	}
 }
 
-func TestRunCLITranscriptAndAccumulation(t *testing.T) {
+// TestRunCLIAccumulation pins that one in-memory server lives for the whole
+// call: history accumulates across input lines, visible in the second
+// response's thoughtHistoryLength.
+func TestRunCLIAccumulation(t *testing.T) {
 	in := strings.Join([]string{
 		`{"thought":"first","thoughtNumber":1,"totalThoughts":2,"nextThoughtNeeded":true,"confidence":0.5,"assumptions":[],"critique":"c","counterArgument":"ca","nextStepRationale":"continue"}`,
 		`{"thought":"second","thoughtNumber":2,"totalThoughts":2,"nextThoughtNeeded":false,"confidence":0.7,"assumptions":[],"critique":"c2","counterArgument":"ca2"}`,
 	}, "\n") + "\n"
 
 	var out, errb bytes.Buffer
-	code := runCLI(strings.NewReader(in), &out, &errb, false)
+	code := runCLI(strings.NewReader(in), &out, &errb)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr = %s", code, errb.String())
 	}
-	s := out.String()
-	if !strings.Contains(s, "Thought 1 of 2") || !strings.Contains(s, "Thought 2 of 2") {
-		t.Errorf("missing thought headers:\n%s", s)
+	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 NDJSON lines, got %d:\n%s", len(lines), out.String())
 	}
-	if !strings.Contains(s, "across 2 thoughts") {
-		t.Errorf("expected accumulated footer 'across 2 thoughts':\n%s", s)
+	var resp thinking.ThoughtResponse
+	if err := json.Unmarshal([]byte(lines[1]), &resp); err != nil {
+		t.Fatalf("second line is not a ThoughtResponse: %v\n%s", err, lines[1])
+	}
+	if resp.ThoughtNumber != 2 || resp.ThoughtHistoryLength != 2 {
+		t.Errorf("second resp = %+v; want thoughtNumber 2, thoughtHistoryLength 2", resp)
 	}
 }
 
@@ -50,44 +57,37 @@ func TestRunCLIMalformedLineContinues(t *testing.T) {
 	in := "{not json\n" +
 		`{"thought":"ok","thoughtNumber":1,"totalThoughts":1,"nextThoughtNeeded":false,"confidence":0.5,"assumptions":[],"critique":"c","counterArgument":"ca"}` + "\n"
 	var out, errb bytes.Buffer
-	code := runCLI(strings.NewReader(in), &out, &errb, false)
+	code := runCLI(strings.NewReader(in), &out, &errb)
 	if code != 1 {
 		t.Errorf("exit = %d; want 1", code)
 	}
 	if !strings.Contains(errb.String(), "line 1") {
 		t.Errorf("stderr should reference line 1: %q", errb.String())
 	}
-	if !strings.Contains(out.String(), "Thought 1 of 1") {
+	if !strings.Contains(out.String(), `"thoughtHistoryLength"`) {
 		t.Errorf("a valid line after a bad one must still render:\n%s", out.String())
 	}
 }
 
+// TestRunCLIValidationErrorRouting pins that a line the engine rejects
+// (IsError) emits its error JSON to stdout — never stderr — so the NDJSON
+// stream stays complete and parseable line-for-line.
 func TestRunCLIValidationErrorRouting(t *testing.T) {
 	// Missing required "critique" → validation error result (IsError).
 	bad := `{"thought":"x","thoughtNumber":1,"totalThoughts":1,"nextThoughtNeeded":false,"confidence":0.5,"assumptions":[],"counterArgument":"ca"}` + "\n"
 
-	// default mode: error JSON to stderr, nothing to stdout.
 	var out, errb bytes.Buffer
-	if code := runCLI(strings.NewReader(bad), &out, &errb, false); code != 1 {
-		t.Errorf("default mode exit = %d; want 1", code)
+	if code := runCLI(strings.NewReader(bad), &out, &errb); code != 1 {
+		t.Errorf("exit = %d; want 1", code)
 	}
-	if out.Len() != 0 || !strings.Contains(errb.String(), `"status":"failed"`) {
-		t.Errorf("default: want error JSON on stderr only; out=%q err=%q", out.String(), errb.String())
-	}
-
-	// -json mode: error JSON to stdout (keeps the NDJSON stream complete).
-	var out2, errb2 bytes.Buffer
-	if code := runCLI(strings.NewReader(bad), &out2, &errb2, true); code != 1 {
-		t.Errorf("json mode exit = %d; want 1", code)
-	}
-	if !strings.Contains(out2.String(), `"status":"failed"`) || errb2.Len() != 0 {
-		t.Errorf("json: error JSON should go to stdout only; out=%q err=%q", out2.String(), errb2.String())
+	if !strings.Contains(out.String(), `"status":"failed"`) || errb.Len() != 0 {
+		t.Errorf("error JSON should go to stdout only; out=%q err=%q", out.String(), errb.String())
 	}
 }
 
 func TestRunCLIBlankAndEmpty(t *testing.T) {
 	var out, errb bytes.Buffer
-	if code := runCLI(strings.NewReader("\n   \n"), &out, &errb, false); code != 0 || out.Len() != 0 {
+	if code := runCLI(strings.NewReader("\n   \n"), &out, &errb); code != 0 || out.Len() != 0 {
 		t.Errorf("blank/empty: code=%d out=%q", code, out.String())
 	}
 }
@@ -101,7 +101,7 @@ func TestCliCmdExitsNonZeroOnAnyFailureAfterProcessingAll(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&errBuf)
-	cmd.SetArgs([]string{"--json"})
+	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
 	if !errors.Is(err, errCLIFailed) {

--- a/cmd/critical-thinking/root.go
+++ b/cmd/critical-thinking/root.go
@@ -25,7 +25,7 @@ func newRootCmd() *cobra.Command {
 			"default, or --http for Streamable HTTP). See the subcommands below.",
 		Example: "  critical-thinking serve\n" +
 			"  critical-thinking serve --http :3000\n" +
-			"  critical-thinking cli --json\n" +
+			"  critical-thinking cli\n" +
 			"  critical-thinking schema\n" +
 			"  critical-thinking version",
 		SilenceUsage:  true,

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -135,17 +135,16 @@ Run the engine directly, without an MCP client:
 
 ```bash
 # Stream thoughts: one ThoughtData JSON object per line on stdin.
+# Output is structured ThoughtResponse NDJSON: one JSON object per line.
 printf '%s\n' '{"thought":"...","thoughtNumber":1,"totalThoughts":3,"nextThoughtNeeded":true,"confidence":0.6,"assumptions":[],"critique":"...","counterArgument":"...","nextStepRationale":"..."}' \
   | critical-thinking cli
-
-# Structured NDJSON output instead of the transcript:
-... | critical-thinking cli --json
 
 # Print the tool contract (description + JSON Schemas) for a model to read:
 critical-thinking schema
 ```
 
 `critical-thinking cli` keeps one in-memory session for the process, so history, confidence, and
-branches accumulate across input lines. Validation/parse errors are written to
-stderr (or to stdout in `--json` mode, to keep the stream complete) and the
-process continues; the exit code is `1` if any line errored, else `0`.
+branches accumulate across input lines. Malformed-JSON lines are diagnosed on
+stderr; a line the engine rejects emits its JSON error object to stdout (to keep
+the stream complete) and the process continues; the exit code is `1` if any line
+errored, else `0`.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,6 +2,24 @@
 
 Cumulative breaking-change log for `critical-thinking`. Most recent changes first.
 
+## `cli` always emits JSON; `--json` flag removed
+
+**Breaking (cli invocation).** `critical-thinking cli` now always prints structured
+`ThoughtResponse` NDJSON — the former `--json` behavior is the only output format,
+and the narrated-transcript mode is gone. `cli` is driven over stdio pipes, where
+the machine-readable stream is the only useful surface.
+
+| Old | New |
+|---|---|
+| `critical-thinking cli --json` | `critical-thinking cli` |
+| `critical-thinking cli` (transcript) | removed — output is always NDJSON |
+
+Passing `--json` now fails with `unknown flag: --json`. Error routing follows the
+former `--json` semantics: engine-rejected lines emit their `{error, status:"failed"}`
+JSON to **stdout** (keeping the stream line-aligned); malformed-JSON lines are
+diagnosed on stderr. `version --json` is unaffected. No engine, field, schema, or
+transport behavior changed.
+
 ### Per-episode isolation + self-correcting validation (#32, #65)
 
 Non-breaking, additive.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,17 +72,16 @@ host required. This is **not** an MCP integration: no host is involved and no
 agent, script, or orchestrator emit NDJSON `ThoughtData` (one JSON object per
 line) and read the result back.
 
-- `critical-thinking cli` prints a narrated transcript to stdout.
-- `critical-thinking cli --json` prints structured `ThoughtResponse` as NDJSON —
-  the machine-readable surface for programmatic callers.
+- `critical-thinking cli` prints structured `ThoughtResponse` as NDJSON — one
+  JSON object per processed line, the machine-readable surface for programmatic
+  callers.
 
 History, confidence, and branches accumulate across input lines that share an
 `episodeId` (absent → the `"default"` episode) within one run
 (the analog of a single stdio MCP session). Every line is processed; the command
-exits non-zero if any line fails. A malformed-JSON line is reported on stderr (in
-both modes). A line the engine rejects (for example a validation error) is
-reported on stderr in the default mode, or — in `--json` mode — emitted to stdout
-as a JSON error object (`{"error":…,"status":"failed"}`) so the `--json` stream
+exits non-zero if any line fails. A malformed-JSON line is reported on stderr. A
+line the engine rejects (for example a validation error) is emitted to stdout
+as a JSON error object (`{"error":…,"status":"failed"}`) so the output stream
 stays complete and parseable line-for-line.
 
 Each `ThoughtData` line must carry the required fields — `thought`,
@@ -109,61 +108,7 @@ critical-thinking cli <<'EOF'
 EOF
 ```
 
-Narrated output:
-
-```
-Thought 1 of 3 · confidence 0.60
-
-Reads dominate writes here, so I'll normalize the schema first.
-
-  Assumptions:
-    - read:write ratio is ~10:1
-
-  Critique:
-    I jumped to a solution before confirming the ratio.
-
-  Counter-argument:
-    If writes dominate, a denormalized store is simpler.
-
-  Next, I want to: Verify the read:write ratio before committing to normalization.
-
-— session confidence 0.60 across 1 thought
-
-Revision of thought 1 (now thought 2) · confidence 0.70
-
-Correction: the measured ratio is ~2:1, so normalization is far less decisive.
-
-  Assumptions:
-    - measured read:write ratio is 2:1
-
-  Critique:
-    My first thought over-weighted reads on an unverified 10:1 guess.
-
-  Counter-argument:
-    Even at 2:1 reads still lead, so normalizing isn't wrong, just weaker.
-
-  Next, I want to: Weigh write-amplification against the modest read advantage.
-
-— session confidence 0.65 across 2 thoughts
-
-Branch 'denormalized' from thought 1 · confidence 0.50
-
-Branch: keep one denormalized table and accept write fan-out instead.
-
-  Assumptions:
-    - write fan-out stays under 3x
-
-  Critique:
-    This trades read simplicity for a write cost I have not measured.
-
-  Counter-argument:
-    If fan-out exceeds 3x, this branch is worse than normalizing.
-
-— branch 'denormalized' confidence 0.50 across 1 thought
-— session confidence (trunk) 0.65 across 2 thoughts
-```
-
-The same input with `--json` yields one `ThoughtResponse` per line:
+Output — one `ThoughtResponse` per line:
 
 ```
 {"thoughtNumber":1,"totalThoughts":3,"nextThoughtNeeded":true,"branches":[],"thoughtHistoryLength":1,"sessionConfidence":0.6}


### PR DESCRIPTION
## Summary
- `cli` is invoked over stdio by an LLM/tool, never interactively by a human, so the narrated-transcript output mode served no purpose.
- `cli` now always emits structured `ThoughtResponse` NDJSON — the former `--json` behavior is the only output format. The `--json` flag is removed; passing it now fails with `unknown flag: --json`.
- Error routing keeps the former `--json` semantics: engine-rejected lines emit `{error, status:"failed"}` JSON to stdout (keeping the NDJSON stream line-aligned); malformed-JSON lines are diagnosed on stderr.
- `version --json` is unaffected — this only touches the `cli` subcommand.
- Docs (`docs/usage.md`, `docs/clients.md`) updated to describe the single output mode; `docs/migration.md` documents the breaking change.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` — 103 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01392A4511uPGPMdBt8z7w4q