### PR TITLE
refactor: modernize Go 1.26 idioms and drop unused sessionRegistry.add() param

### DIFF
--- a/cmd/critical-thinking/mcpserver.go
+++ b/cmd/critical-thinking/mcpserver.go
@@ -75,7 +75,7 @@ func runHTTP(cfg httpConfig, addr string) error {
 
 	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		state := thinking.NewServer()
-		registry.add(state)
+		registry.add()
 		slog.Debug("http session created", "sessionsCreated", registry.count())
 		return newMCPServer(state)
 	}, &mcp.StreamableHTTPOptions{
@@ -128,9 +128,9 @@ func newMCPServer(state *thinking.SequentialThinkingServer) *mcp.Server {
 		Description: thinking.ToolDescription,
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:    true,
-			DestructiveHint: ptrFalse(),
+			DestructiveHint: new(false),
 			IdempotentHint:  true,
-			OpenWorldHint:   ptrFalse(),
+			OpenWorldHint:   new(false),
 		},
 	}, makeToolHandler(state))
 
@@ -143,8 +143,6 @@ func newMCPServer(state *thinking.SequentialThinkingServer) *mcp.Server {
 
 	return srv
 }
-
-func ptrFalse() *bool { f := false; return &f }
 
 // makeToolHandler closes over a per-session state and returns the Go SDK's
 // expected handler signature. The second return value (any) becomes the
@@ -208,10 +206,8 @@ type sessionRegistry struct {
 
 func newSessionRegistry() *sessionRegistry { return &sessionRegistry{} }
 
-// add records that a session was created. The *SequentialThinkingServer
-// argument is intentionally not retained (that would pin closed-session state);
-// it is kept in the signature so the call site reads naturally.
-func (r *sessionRegistry) add(*thinking.SequentialThinkingServer) { r.created.Add(1) }
+// add records that a session was created.
+func (r *sessionRegistry) add() { r.created.Add(1) }
 
 func (r *sessionRegistry) count() int { return int(r.created.Load()) }
 

--- a/cmd/critical-thinking/mcpserver_test.go
+++ b/cmd/critical-thinking/mcpserver_test.go
@@ -78,7 +78,7 @@ func TestSessionRegistryCountsCreations(t *testing.T) {
 	const n = 50
 	var wg sync.WaitGroup
 	for range n {
-		wg.Go(func() { r.add(thinking.NewServer()) })
+		wg.Go(func() { r.add() })
 	}
 	wg.Wait()
 	if got := r.count(); got != n {
@@ -88,8 +88,8 @@ func TestSessionRegistryCountsCreations(t *testing.T) {
 
 func TestHealthEndpoint(t *testing.T) {
 	registry := newSessionRegistry()
-	registry.add(thinking.NewServer())
-	registry.add(thinking.NewServer())
+	registry.add()
+	registry.add()
 
 	h := makeHealthHandler(registry)
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
@@ -262,7 +262,7 @@ func TestCrossSessionIsolation(t *testing.T) {
 	registry := newSessionRegistry()
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
 		state := thinking.NewServer()
-		registry.add(state)
+		registry.add()
 		return newMCPServer(state)
 	}, nil)
 	mux := http.NewServeMux()
@@ -316,7 +316,7 @@ func TestThinkingCurrentResourceIsPerSession(t *testing.T) {
 	registry := newSessionRegistry()
 	mcpHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
 		state := thinking.NewServer()
-		registry.add(state)
+		registry.add()
 		return newMCPServer(state)
 	}, nil)
 	mux := http.NewServeMux()

--- a/internal/thinking/server.go
+++ b/internal/thinking/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -240,7 +241,7 @@ func (s *SequentialThinkingServer) ProcessThought(td ThoughtData) (ToolResult, e
 		ThoughtNumber:        td.ThoughtNumber,
 		TotalThoughts:        td.TotalThoughts,
 		NextThoughtNeeded:    *td.NextThoughtNeeded,
-		Branches:             sortedKeys(ep.branches),
+		Branches:             slices.Sorted(maps.Keys(ep.branches)),
 		ThoughtHistoryLength: len(ep.thoughtHistory),
 		SessionConfidence:    sessionConf,
 		BranchConfidences:    branchConf,
@@ -372,15 +373,6 @@ func errorResult(err error) ToolResult {
 		Status string `json:"status"`
 	}{Error: err.Error(), Status: "failed"})
 	return ToolResult{Text: string(body), IsError: true}
-}
-
-func sortedKeys(m map[string][]ThoughtData) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-	return keys
 }
 
 // HistorySnapshot returns a deep copy of the trunk + branch thought history,


### PR DESCRIPTION
## Summary
- `ptrFalse()` → `new(false)` (Go 1.26 idiom)
- `sortedKeys` helper → `slices.Sorted(maps.Keys(...))` (Go 1.23 idiom)
- `sessionRegistry.add()` drops its unused parameter — now `add()`, no argument

Pure, behavior-preserving refactor. No functional change; `sessionRegistry`'s counter and the `/health` `sessionsCreated` field are unchanged.

This is the first of a three-plan dependency chain (#72 → #75 → #76). The new `sessionRegistry.add()` no-argument signature is a hard prerequisite for both later plans.

Closes #72.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` (clean)
- [x] `go test ./... -race` — 103 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01392A4511uPGPMdBt8z7w4q