### PR TITLE
refactor(thinking): collapse error-result JSON builders into one encoder

### DIFF
--- a/internal/thinking/contract_test.go
+++ b/internal/thinking/contract_test.go
@@ -67,6 +67,14 @@ func TestRangeErrorOmitsHint(t *testing.T) {
 	if p.Hint != "" {
 		t.Errorf("range error must not carry a hint; got %q", p.Hint)
 	}
+	// The hint key must be absent from the wire, not present-but-empty.
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(res.Text), &raw); err != nil {
+		t.Fatalf("error result is not JSON: %v", err)
+	}
+	if _, ok := raw["hint"]; ok {
+		t.Errorf("range error must not carry a hint key on the wire; got %s", res.Text)
+	}
 }
 
 func TestToolDescriptionContractGuards(t *testing.T) {

--- a/internal/thinking/server.go
+++ b/internal/thinking/server.go
@@ -178,7 +178,7 @@ type ToolResult struct {
 // returned); validation failures produce IsError=true results.
 func (s *SequentialThinkingServer) ProcessThought(td ThoughtData) (ToolResult, error) {
 	if err := td.Validate(); err != nil {
-		return validationErrorResult(err), nil
+		return errorResultWithHint(err, requiredFieldsChecklist), nil
 	}
 
 	// Resolve the logical episode. Empty means the "default" episode. This is
@@ -349,29 +349,25 @@ func (e *episode) renderFooter(b *strings.Builder, td ThoughtData, sessionConf f
 		sessionConf, e.confidenceN, noun)
 }
 
-// validationErrorResult formats a contract-validation failure like errorResult
-// but adds a self-correcting `hint` listing every required field, so the caller
-// can fix the next call without a second rejection. Used ONLY for Validate()
-// failures — not for the state-dependent range errors, where a field checklist
-// would be misleading noise.
-func validationErrorResult(err error) ToolResult {
+// errorResultWithHint is the single encoder for the JS-compatible on-wire error
+// envelope {error, status:"failed"[, hint]}. An empty hint omits the key.
+// The hint (the required-fields checklist) is used ONLY for Validate() failures —
+// not for state-dependent range errors, where a field checklist would be
+// misleading noise.
+func errorResultWithHint(err error, hint string) ToolResult {
+	// Marshaling a fixed-shape struct of strings cannot fail.
 	body, _ := json.Marshal(struct {
 		Error  string `json:"error"`
 		Status string `json:"status"`
-		Hint   string `json:"hint"`
-	}{Error: err.Error(), Status: "failed", Hint: requiredFieldsChecklist})
+		Hint   string `json:"hint,omitempty"`
+	}{Error: err.Error(), Status: "failed", Hint: hint})
 	return ToolResult{Text: string(body), IsError: true}
 }
 
 // errorResult formats a validation/runtime error in the JS-compatible
-// {error, status: "failed"} shape.
+// {error, status: "failed"} shape, with no hint.
 func errorResult(err error) ToolResult {
-	// Marshaling a fixed-shape {string,string} struct cannot fail.
-	body, _ := json.Marshal(struct {
-		Error  string `json:"error"`
-		Status string `json:"status"`
-	}{Error: err.Error(), Status: "failed"})
-	return ToolResult{Text: string(body), IsError: true}
+	return errorResultWithHint(err, "")
 }
 
 func sortedKeys(m map[string][]ThoughtData) []string {


### PR DESCRIPTION
## Summary
- Collapses `errorResult` and `validationErrorResult` into a single `errorResultWithHint` encoder; `errorResult` becomes a thin wrapper with `hint=""`.
- Wire output is byte-identical for both shapes (with-hint and no-hint), guaranteed by preserved field order (`Error, Status, Hint`) and `omitempty` on `Hint`.
- Strengthens `TestRangeErrorOmitsHint` with a key-absence assertion (unmarshal into a map and check the `hint` key isn't just empty-string, but fully absent from the wire).

Closes #73.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` — 103 passed
- [x] `grep -rn "validationErrorResult" internal/` — no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01392A4511uPGPMdBt8z7w4q