### PR TITLE
fix(plugin): harden install/release pipeline (checksum verification + narrower hook matcher)

### DIFF
--- a/plugins/critical-thinking/hooks/hooks.json
+++ b/plugins/critical-thinking/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear|compact",
+        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",

--- a/plugins/critical-thinking/hooks/install-binary.sh
+++ b/plugins/critical-thinking/hooks/install-binary.sh
@@ -11,9 +11,13 @@
 #
 # Behavior:
 #   - Binary present AND .installed-version == EXPECTED_VERSION -> no-op.
-#   - Otherwise -> download EXPECTED_VERSION's archive, install, record version.
-#   - Download fails AND a binary already exists -> keep it, warn, exit 0.
-#   - Download fails AND no binary exists -> fail loudly (exit 1).
+#   - Otherwise -> download EXPECTED_VERSION's archive + checksums.txt, verify the
+#     SHA-256, extract, install, record version.
+#   - Archive OR checksums download fails (network) AND a binary already exists ->
+#     keep it, warn, exit 0. No existing binary -> fail loudly (exit 1). Never
+#     installs an unverified binary.
+#   - Checksum MISMATCH (possible tampering/corruption) -> always fail closed
+#     (exit 1); the artifact is never made executable.
 #
 # Force re-download: delete ${CLAUDE_PLUGIN_ROOT}/bin/critical-thinking.
 # Windows note: requires Git Bash / WSL / another POSIX shell.
@@ -57,7 +61,9 @@ esac
 VERSION="${EXPECTED_VERSION#v}"
 EXT="tar.gz"
 [[ "${OS}" == "windows" ]] && EXT="zip"
-URL="https://github.com/${REPO}/releases/download/${EXPECTED_VERSION}/${PROJECT}_${VERSION}_${OS}_${ARCH}.${EXT}"
+ARCHIVE_NAME="${PROJECT}_${VERSION}_${OS}_${ARCH}.${EXT}"
+URL="https://github.com/${REPO}/releases/download/${EXPECTED_VERSION}/${ARCHIVE_NAME}"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${EXPECTED_VERSION}/checksums.txt"
 
 echo "critical-thinking: installing ${EXPECTED_VERSION} from ${URL}" >&2
 
@@ -65,24 +71,51 @@ mkdir -p "${BIN_DIR}"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "${WORK_DIR}"' EXIT
 
-download_ok=1
-if [[ "${EXT}" == "tar.gz" ]]; then
-  curl -fsSL "${URL}" | tar -xzC "${WORK_DIR}" || download_ok=0
-else
-  curl -fsSL -o "${WORK_DIR}/release.zip" "${URL}" || download_ok=0
-  if [[ "${download_ok}" == "1" ]]; then
-    unzip -q "${WORK_DIR}/release.zip" -d "${WORK_DIR}" || download_ok=0
+# Prefer sha256sum (Linux, Git Bash); fall back to shasum -a 256 (macOS default).
+# Reads "<hash>  <name>" lines on stdin; cwd must contain <name>.
+sha256_check() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c -
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c -
+  else
+    echo "critical-thinking: no sha256sum/shasum found; cannot verify integrity" >&2
+    return 1
   fi
-fi
+}
 
-# Download failure: tolerate it if we already have *some* binary; otherwise fail.
-if [[ "${download_ok}" == "0" ]]; then
+# keep_existing_or_fail <reason>: network-class failure. Preserve a working binary
+# if we have one (exit 0); otherwise fail loudly (exit 1). NEVER installs.
+keep_existing_or_fail() {
   if [[ -x "${BIN_PATH}" ]]; then
-    echo "critical-thinking: download failed; keeping existing binary at ${BIN_PATH}" >&2
+    echo "critical-thinking: $1; keeping existing binary at ${BIN_PATH}" >&2
     exit 0
   fi
-  echo "critical-thinking: download failed and no existing binary — check network or install manually" >&2
+  echo "critical-thinking: $1 and no existing binary — check network or install manually" >&2
   exit 1
+}
+
+# Download the archive to a file (must be on disk to hash it).
+curl -fsSL -o "${WORK_DIR}/${ARCHIVE_NAME}" "${URL}" \
+  || keep_existing_or_fail "archive download failed"
+
+# Download the checksums manifest from the same release/tag.
+curl -fsSL -o "${WORK_DIR}/checksums.txt" "${CHECKSUMS_URL}" \
+  || keep_existing_or_fail "checksums download failed"
+
+# Verify integrity BEFORE extracting or installing. A mismatch is a stronger
+# signal than a network failure (possible tampering/corruption of an auto-executed
+# binary), so it ALWAYS fails closed — we never install the artifact.
+if ! ( cd "${WORK_DIR}" && grep " ${ARCHIVE_NAME}\$" checksums.txt | sha256_check ); then
+  echo "critical-thinking: CHECKSUM VERIFICATION FAILED for ${ARCHIVE_NAME} — refusing to install (possible corruption or tampering)" >&2
+  exit 1
+fi
+
+# Verified: extract, then install.
+if [[ "${EXT}" == "tar.gz" ]]; then
+  tar -xzf "${WORK_DIR}/${ARCHIVE_NAME}" -C "${WORK_DIR}"
+else
+  unzip -q "${WORK_DIR}/${ARCHIVE_NAME}" -d "${WORK_DIR}"
 fi
 
 SRC="${WORK_DIR}/${PROJECT}"
@@ -96,4 +129,4 @@ fi
 mv "${SRC}" "${BIN_PATH}"
 chmod +x "${BIN_PATH}"
 printf '%s\n' "${EXPECTED_VERSION}" > "${INSTALLED_VERSION_FILE}"
-echo "critical-thinking: installed ${BIN_PATH} (${EXPECTED_VERSION})" >&2
+echo "critical-thinking: installed ${BIN_PATH} (${EXPECTED_VERSION}, checksum verified)" >&2

--- a/plugins/critical-thinking/test/hooks_json_test.sh
+++ b/plugins/critical-thinking/test/hooks_json_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Asserts hooks.json is valid JSON and the SessionStart matcher is narrowed to
+# startup|resume (issue #77 finding 2 — clear/compact cannot change the on-disk
+# plugin, so the install/version check must not run there).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOKS="${HERE}/../hooks/hooks.json"
+PASS=0; FAIL=0
+
+if jq -e . "${HOOKS}" >/dev/null 2>&1; then echo "ok   - hooks.json is valid JSON"; PASS=$((PASS+1));
+else echo "FAIL - hooks.json invalid JSON"; FAIL=$((FAIL+1)); fi
+
+matcher="$(jq -r '.hooks.SessionStart[0].matcher' "${HOOKS}")"
+if [[ "${matcher}" == "startup|resume" ]]; then echo "ok   - SessionStart matcher narrowed"; PASS=$((PASS+1));
+else echo "FAIL - SessionStart matcher is '${matcher}', expected 'startup|resume'"; FAIL=$((FAIL+1)); fi
+
+echo "---"; echo "PASS=${PASS} FAIL=${FAIL}"
+[[ "${FAIL}" -eq 0 ]]

--- a/plugins/critical-thinking/test/install-binary_test.sh
+++ b/plugins/critical-thinking/test/install-binary_test.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # Tests for install-binary.sh. Each case runs the script in an isolated fake
-# CLAUDE_PLUGIN_ROOT with curl/tar stubbed on PATH so no network is touched.
+# CLAUDE_PLUGIN_ROOT with curl stubbed on PATH so no network is touched. The
+# script's own tar/unzip calls run for real against archives the curl stubs
+# build on disk.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT="${HERE}/../hooks/install-binary.sh"
+BASE_PATH="${PATH}"
 PASS=0
 FAIL=0
 
@@ -13,34 +16,50 @@ check() { # desc, expected_rc, actual_rc
   else echo "FAIL - $1 (expected rc=$2 got rc=$3)"; FAIL=$((FAIL+1)); fi
 }
 
-# Build a throwaway plugin root with a stub bin/ dir on PATH.
+# Build a throwaway plugin root with a stub bin/ dir on PATH. Resets PATH from
+# BASE_PATH each time (rather than prepending onto the already-modified PATH)
+# so a prior case's stub binaries (e.g. stub_fail's no-op tar) never leak into
+# a later case that needs the real tar/unzip on the system PATH.
 new_root() {
   ROOT="$(mktemp -d)"
   STUB="$(mktemp -d)"
   mkdir -p "${ROOT}/bin"
   export CLAUDE_PLUGIN_ROOT="${ROOT}"
-  export PATH="${STUB}:${PATH}"
+  export PATH="${STUB}:${BASE_PATH}"
   STUBDIR="${STUB}"
 }
 
-# Stub curl/tar that "downloads" a fake binary into the extraction dir.
-stub_success() {
-  cat >"${STUBDIR}/curl" <<'EOS'
+# Stub curl that emulates: curl -fsSL -o <out> <url>. Serves a fixed archive for
+# the release-archive URL and publishes its real SHA-256 for checksums.txt
+# (MODE=bad substitutes a wrong hash to simulate tampering/corruption). Used for
+# both the plain "successful download" cases and the dedicated checksum cases,
+# since both need a real archive on disk whose published hash matches the bytes
+# curl actually served.
+stub_checksum() {  # $1 = ok|bad
+  MODE="$1"
+  cat >"${STUBDIR}/curl" <<EOS
 #!/usr/bin/env bash
-# locate -C target dir from a piped tar, or -o file; emulate by writing marker
-# We cooperate with the tar stub below via a shared temp marker file.
+# Emulate: curl -fsSL -o <out> <url>. Serve a fixed archive; publish its real hash.
+out=""; prev=""; url=""
+for a in "\$@"; do [[ "\$prev" == "-o" ]] && out="\$a"; prev="\$a"; url="\$a"; done
+[[ -z "\$out" ]] && exit 22
+shared="${STUBDIR}/served-archive.tar.gz"
+if [[ "\$url" == *checksums.txt ]]; then
+  [[ -f "\$shared" ]] || exit 22
+  if command -v sha256sum >/dev/null 2>&1; then h="\$(sha256sum "\$shared" | awk '{print \$1}')";
+  else h="\$(shasum -a 256 "\$shared" | awk '{print \$1}')"; fi
+  [[ "${MODE}" == "bad" ]] && h="0000000000000000000000000000000000000000000000000000000000000000"
+  printf '%s  %s\n' "\$h" "\$(cat "${STUBDIR}/served-name")" > "\$out"
+  exit 0
+fi
+# archive request: build one fixed tar.gz, serve it, and record its basename.
+t="\$(mktemp -d)"; printf '#!/bin/sh\necho cthink\n' > "\$t/critical-thinking"
+tar -czf "\$shared" -C "\$t" critical-thinking 2>/dev/null
+cp "\$shared" "\$out"
+basename "\$url" > "${STUBDIR}/served-name"
 exit 0
 EOS
-  cat >"${STUBDIR}/tar" <<'EOS'
-#!/usr/bin/env bash
-# args: -xzC <dir> ; create the expected binary there.
-dir=""; prev=""
-for a in "$@"; do [[ "$prev" == "-C" || "$prev" == "-xzC" ]] && dir="$a"; prev="$a"; done
-[[ -z "$dir" ]] && for a in "$@"; do [[ -d "$a" ]] && dir="$a"; done
-printf '#!/bin/sh\necho cthink\n' > "${dir}/critical-thinking"
-exit 0
-EOS
-  chmod +x "${STUBDIR}/curl" "${STUBDIR}/tar"
+  chmod +x "${STUBDIR}/curl"
 }
 
 # Stub curl that fails (network error).
@@ -58,8 +77,8 @@ printf '%s\n' "${EXPECTED}" > "${ROOT}/bin/.installed-version"
 printf '#!/usr/bin/env bash\necho "curl must not run" >&2; exit 99\n' > "${STUBDIR}/curl"; chmod +x "${STUBDIR}/curl"
 bash "${SCRIPT}"; check "fast-path no-op when version matches" 0 $?
 
-# Case 2: version mismatch triggers a (stubbed) successful download.
-new_root; stub_success
+# Case 2: version mismatch triggers a (stubbed) successful, checksum-verified download.
+new_root; stub_checksum ok
 printf 'old\n' > "${ROOT}/bin/.installed-version"
 bash "${SCRIPT}"; rc=$?
 check "mismatch downloads new binary" 0 "${rc}"
@@ -77,6 +96,49 @@ bash "${SCRIPT}"; check "download fail + existing binary tolerated" 0 $?
 # Case 4: download fails and no binary exists (exit 1).
 new_root; stub_fail
 bash "${SCRIPT}"; check "download fail + no binary fails loudly" 1 $?
+
+# --- Checksum verification cases (issue #77) ---
+
+# Case 5: checksum match -> installs and records version.
+new_root; stub_checksum ok
+printf 'old\n' > "${ROOT}/bin/.installed-version"
+bash "${SCRIPT}"; rc=$?
+check "checksum match installs" 0 "${rc}"
+if [[ -x "${ROOT}/bin/critical-thinking" && "$(cat "${ROOT}/bin/.installed-version" 2>/dev/null)" == "${EXPECTED}" ]]; then
+  echo "ok   - verified binary installed"; PASS=$((PASS+1));
+else echo "FAIL - verified binary not installed"; FAIL=$((FAIL+1)); fi
+
+# Case 6: checksum MISMATCH -> exit 1 and no install.
+new_root; stub_checksum bad
+bash "${SCRIPT}"; check "checksum mismatch fails closed" 1 $?
+if [[ ! -e "${ROOT}/bin/critical-thinking" ]]; then echo "ok   - no binary on mismatch"; PASS=$((PASS+1));
+else echo "FAIL - binary installed despite mismatch"; FAIL=$((FAIL+1)); fi
+
+# Case 7: checksums.txt unreachable but existing binary -> keep, exit 0.
+new_root
+cat >"${STUBDIR}/curl" <<'EOS'
+#!/usr/bin/env bash
+out=""; prev=""; url=""
+for a in "$@"; do [[ "$prev" == "-o" ]] && out="$a"; prev="$a"; url="$a"; done
+if [[ "$url" == *checksums.txt ]]; then exit 22; fi   # checksums fail
+t="$(mktemp -d)"; printf 'x\n' > "$t/critical-thinking"; tar -czf "$out" -C "$t" critical-thinking 2>/dev/null; exit 0
+EOS
+chmod +x "${STUBDIR}/curl"
+printf 'stub\n' > "${ROOT}/bin/critical-thinking"; chmod +x "${ROOT}/bin/critical-thinking"
+printf 'old\n' > "${ROOT}/bin/.installed-version"
+bash "${SCRIPT}"; check "checksums unreachable + existing binary tolerated" 0 $?
+
+# Case 8: checksums.txt unreachable and no binary -> exit 1.
+new_root
+cat >"${STUBDIR}/curl" <<'EOS'
+#!/usr/bin/env bash
+out=""; prev=""; url=""
+for a in "$@"; do [[ "$prev" == "-o" ]] && out="$a"; prev="$a"; url="$a"; done
+if [[ "$url" == *checksums.txt ]]; then exit 22; fi
+t="$(mktemp -d)"; printf 'x\n' > "$t/critical-thinking"; tar -czf "$out" -C "$t" critical-thinking 2>/dev/null; exit 0
+EOS
+chmod +x "${STUBDIR}/curl"
+bash "${SCRIPT}"; check "checksums unreachable + no binary fails" 1 $?
 
 echo "---"; echo "PASS=${PASS} FAIL=${FAIL}"
 [[ "${FAIL}" -eq 0 ]]


### PR DESCRIPTION
## Summary
- Adds SHA-256 checksum verification to the plugin binary installer (`install-binary.sh`): downloads the archive and `checksums.txt` from the same release, verifies with a portable `sha256sum`/`shasum` selector *before* extraction, and only then installs.
- Fail-mode matrix: hash mismatch always fails closed (`exit 1`, never installs); network failure (archive or checksums unreachable) keeps an existing binary if present (`exit 0`), else fails (`exit 1`); never installs an unverified artifact.
- Narrows the `SessionStart` hook matcher from `startup|resume|clear|compact` to `startup|resume` — `clear`/`compact` are mid-session context ops that can't change the on-disk plugin, so re-running the install/version check there was conceptually wrong (and wasted work every context clear/compact).
- The `EXPECTED_VERSION="vX.Y.Z"` line shape (column 0) is preserved — release automation (`scripts/bump-plugin-version.mjs`) depends on it.

Closes #77.

## Test plan
- [x] `plugins/critical-thinking/test/install-binary_test.sh` — PASS=12 FAIL=0 (cases 1-4 pre-existing, 5-8 new checksum-path coverage)
- [x] `plugins/critical-thinking/test/hooks_json_test.sh` — PASS=2 FAIL=0 (new)
- [x] `shellcheck` clean on both changed scripts
- [x] `go build ./...`
- [x] Task-scoped review + independent final whole-branch review, both clean (security-focused: fail-closed traced on every path — mismatch, archive-download failure, checksums-download failure, missing hash tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01392A4511uPGPMdBt8z7w4q