### PR TITLE
feat(cli): add --once single-shot mode

### DIFF
--- a/cmd/critical-thinking/cli.go
+++ b/cmd/critical-thinking/cli.go
@@ -23,10 +23,8 @@ var errCLIFailed = errors.New("cli: one or more input lines failed")
 // One in-memory thinking.NewServer() lives for the call, so history,
 // confidence, and branches accumulate across input lines — the analog of a
 // stdio MCP session. Input is NDJSON: one ThoughtData per non-blank line.
-// Output is NDJSON too: one structured ThoughtResponse per processed line. A
-// line the engine rejects emits its error JSON to stdout so the stream stays
-// line-aligned; malformed-JSON lines are diagnosed on stderr only. Returns 0
-// if every line succeeded, 1 if any line errored.
+// Output is NDJSON too: one structured ThoughtResponse per processed line.
+// Returns 0 if every line succeeded, 1 if any line errored.
 func runCLI(stdin io.Reader, stdout, stderr io.Writer) int {
 	state := thinking.NewServer()
 	sc := bufio.NewScanner(stdin)
@@ -39,26 +37,9 @@ func runCLI(stdin io.Reader, stdout, stderr io.Writer) int {
 		if len(line) == 0 {
 			continue
 		}
-		var td thinking.ThoughtData
-		// Write errors on stdout/stderr aren't actionable here; the exit code
-		// already reflects per-line success via failed.
-		if err := json.Unmarshal(line, &td); err != nil {
-			_, _ = fmt.Fprintf(stderr, "cli: line %d: %v\n", lineNo, err)
+		if !processOne(state, line, fmt.Sprintf("line %d", lineNo), stdout, stderr) {
 			failed = true
-			continue
 		}
-		res, err := state.ProcessThought(td)
-		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "cli: line %d: %v\n", lineNo, err)
-			failed = true
-			continue
-		}
-		if res.IsError {
-			failed = true
-			_, _ = fmt.Fprintln(stdout, res.Text) // error JSON keeps NDJSON aligned
-			continue
-		}
-		_, _ = fmt.Fprintln(stdout, res.StructuredJSON)
 	}
 	if err := sc.Err(); err != nil {
 		_, _ = fmt.Fprintf(stderr, "cli: read: %v\n", err)
@@ -68,6 +49,34 @@ func runCLI(stdin io.Reader, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+// processOne unmarshals one ThoughtData JSON document from raw, processes it
+// against state, and writes the result — the single source of the per-input
+// contract shared by the stream loop and --once. src labels the input in
+// diagnostics ("line 3", "argument", "stdin"). Success emits StructuredJSON
+// to stdout; an IsError result emits the engine's error JSON to stdout too,
+// so the NDJSON stream stays line-aligned. Malformed input is diagnosed on
+// stderr only. Returns false if the input failed.
+func processOne(state *thinking.SequentialThinkingServer, raw []byte, src string, stdout, stderr io.Writer) bool {
+	var td thinking.ThoughtData
+	// Write errors on stdout/stderr aren't actionable here; the return value
+	// already reflects per-input success.
+	if err := json.Unmarshal(raw, &td); err != nil {
+		_, _ = fmt.Fprintf(stderr, "cli: %s: %v\n", src, err)
+		return false
+	}
+	res, err := state.ProcessThought(td)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "cli: %s: %v\n", src, err)
+		return false
+	}
+	if res.IsError {
+		_, _ = fmt.Fprintln(stdout, res.Text) // error JSON keeps NDJSON aligned
+		return false
+	}
+	_, _ = fmt.Fprintln(stdout, res.StructuredJSON)
+	return true
 }
 
 // newCliCmd streams NDJSON ThoughtData from stdin through the engine (no MCP),

--- a/cmd/critical-thinking/cli.go
+++ b/cmd/critical-thinking/cli.go
@@ -79,6 +79,35 @@ func processOne(state *thinking.SequentialThinkingServer, raw []byte, src string
 	return true
 }
 
+// runOnce processes exactly one ThoughtData through a fresh in-memory server
+// and exits — the single-shot analog of runCLI for scripting/testing (#74).
+// The document comes from arg when non-nil, else from ALL of stdin — one JSON
+// document, so pretty-printed multi-line JSON is fine, unlike the NDJSON
+// loop. Empty input and trailing data after the document are unmarshal
+// failures: with no next line to continue to, --once has nothing to skip.
+// Returns 0 on success, 1 on any failure.
+func runOnce(arg *string, stdin io.Reader, stdout, stderr io.Writer) int {
+	var raw []byte
+	src := "stdin"
+	if arg != nil {
+		raw, src = []byte(*arg), "argument"
+	} else {
+		// Unbounded by design: the stream loop's 1 MiB buffer is a
+		// bufio.Scanner token-size mechanism, not an input-size contract
+		// (serve mode reads unbounded JSON-RPC frames too). Design §5.2.
+		b, err := io.ReadAll(stdin)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "cli: read: %v\n", err)
+			return 1
+		}
+		raw = b
+	}
+	if processOne(thinking.NewServer(), raw, src, stdout, stderr) {
+		return 0
+	}
+	return 1
+}
+
 // newCliCmd streams NDJSON ThoughtData from stdin through the engine (no MCP),
 // emitting one structured ThoughtResponse JSON object per line. It processes
 // EVERY line, then returns errCLIFailed iff any line failed, so the exit code

--- a/cmd/critical-thinking/cli.go
+++ b/cmd/critical-thinking/cli.go
@@ -12,12 +12,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// errCLIFailed is the sentinel returned by the cli command's RunE when at least
-// one input line failed. runCLI has already written per-line diagnostics to
-// stderr; this sentinel drives main()'s exit code to 1. The root leaves
-// SilenceErrors=false, so cobra also prints this error's message to stderr as a
-// one-line summary — never to stdout.
-var errCLIFailed = errors.New("cli: one or more input lines failed")
+// errCLIFailed is the sentinel returned by the cli command's RunE when input
+// failed to process (any line in stream mode; the single document in --once
+// mode). runCLI/runOnce have already written diagnostics to stderr; this
+// sentinel drives main()'s exit code to 1. The root leaves
+// SilenceErrors=false, so cobra also prints this error's message to stderr as
+// a one-line summary — never to stdout.
+var errCLIFailed = errors.New("cli: input failed")
 
 // runCLI runs the thinking engine over a plain stdin→stdout loop (no MCP).
 // One in-memory thinking.NewServer() lives for the call, so history,
@@ -109,20 +110,41 @@ func runOnce(arg *string, stdin io.Reader, stdout, stderr io.Writer) int {
 }
 
 // newCliCmd streams NDJSON ThoughtData from stdin through the engine (no MCP),
-// emitting one structured ThoughtResponse JSON object per line. It processes
-// EVERY line, then returns errCLIFailed iff any line failed, so the exit code
-// is 1 without fail-fast (pin 1).
+// emitting one structured ThoughtResponse JSON object per line. Stream mode
+// processes EVERY line, then returns errCLIFailed iff any line failed, so the
+// exit code is 1 without fail-fast (pin 1). --once instead processes exactly
+// one ThoughtData — from the positional argument, or stdin when omitted —
+// against a fresh server, and exits 0/1 (#74).
 func newCliCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "cli",
-		Short: "Stream NDJSON ThoughtData through the engine (no MCP host)",
-		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			code := runCLI(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+	var once bool
+	cmd := &cobra.Command{
+		Use:   "cli [thought-json]",
+		Short: "Process ThoughtData through the engine, streamed via stdin or as a single --once call (no MCP host)",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// The positional is only meaningful in --once mode; rejecting it
+			// otherwise keeps the stream contract unchanged. Checked here (not
+			// a custom Args validator) so the flag value is unambiguously
+			// parsed and all mode logic reads top-to-bottom in one place.
+			if len(args) == 1 && !once {
+				return errors.New("cli: an argument requires --once")
+			}
+			var code int
+			if once {
+				var arg *string
+				if len(args) == 1 {
+					arg = &args[0]
+				}
+				code = runOnce(arg, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+			} else {
+				code = runCLI(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+			}
 			if code != 0 {
 				return errCLIFailed
 			}
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&once, "once", false, "process exactly one ThoughtData (from the argument, or stdin if omitted) and exit")
+	return cmd
 }

--- a/cmd/critical-thinking/cli_test.go
+++ b/cmd/critical-thinking/cli_test.go
@@ -208,3 +208,63 @@ func TestRunOnceTrailingData(t *testing.T) {
 		t.Errorf("exit = %d; want 1", code)
 	}
 }
+
+func TestCliCmdOnceArgSuccess(t *testing.T) {
+	cmd := newCliCmd()
+	cmd.SetIn(strings.NewReader("")) // must NOT be read when the arg is given
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--once", validOnceInput})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() err = %v, want nil", err)
+	}
+	if !strings.Contains(out.String(), `"thoughtHistoryLength":1`) {
+		t.Errorf("expected one ThoughtResponse on stdout: %s", out.String())
+	}
+}
+
+func TestCliCmdOnceStdinFallback(t *testing.T) {
+	cmd := newCliCmd()
+	cmd.SetIn(strings.NewReader(validOnceInput))
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--once"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() err = %v, want nil", err)
+	}
+	if !strings.Contains(out.String(), `"thoughtHistoryLength":1`) {
+		t.Errorf("expected one ThoughtResponse on stdout: %s", out.String())
+	}
+}
+
+func TestCliCmdOnceFailureReturnsSentinel(t *testing.T) {
+	cmd := newCliCmd()
+	cmd.SetIn(strings.NewReader(""))
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"--once", "{not json"})
+	if err := cmd.Execute(); !errors.Is(err, errCLIFailed) {
+		t.Fatalf("Execute() err = %v, want errCLIFailed", err)
+	}
+}
+
+// A positional argument without --once must be rejected, so the stream
+// contract is not silently changed.
+func TestCliCmdArgWithoutOnceRejected(t *testing.T) {
+	cmd := newCliCmd()
+	cmd.SetIn(strings.NewReader(""))
+	var out, errBuf bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{validOnceInput})
+	err := cmd.Execute()
+	if err == nil || errors.Is(err, errCLIFailed) {
+		t.Fatalf("Execute() err = %v, want a usage error distinct from errCLIFailed", err)
+	}
+	if !strings.Contains(err.Error(), "--once") {
+		t.Errorf("error should point at --once: %v", err)
+	}
+}

--- a/cmd/critical-thinking/cli_test.go
+++ b/cmd/critical-thinking/cli_test.go
@@ -123,3 +123,88 @@ func TestCliCmdSuccessReturnsNil(t *testing.T) {
 		t.Fatalf("Execute() err = %v, want nil", err)
 	}
 }
+
+// validOnceInput is one minimal valid ThoughtData document, shared by the
+// --once tests.
+const validOnceInput = `{"thought":"x","thoughtNumber":1,"totalThoughts":1,"nextThoughtNeeded":false,"confidence":0.5,"assumptions":[],"critique":"c","counterArgument":"ca"}`
+
+func TestRunOnceArg(t *testing.T) {
+	arg := validOnceInput
+	var out, errb bytes.Buffer
+	if code := runOnce(&arg, strings.NewReader(""), &out, &errb); code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, errb.String())
+	}
+	var resp thinking.ThoughtResponse
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &resp); err != nil {
+		t.Fatalf("stdout is not a ThoughtResponse: %v\n%s", err, out.String())
+	}
+	if resp.ThoughtNumber != 1 || resp.ThoughtHistoryLength != 1 {
+		t.Errorf("resp = %+v", resp)
+	}
+	if errb.Len() != 0 {
+		t.Errorf("stderr should be empty: %q", errb.String())
+	}
+}
+
+// Pretty-printed multi-line JSON on stdin must work in --once mode — the one
+// input shape the NDJSON stream loop cannot accept.
+func TestRunOnceStdinFallbackPrettyJSON(t *testing.T) {
+	pretty := "{\n  \"thought\": \"x\",\n  \"thoughtNumber\": 1,\n  \"totalThoughts\": 1,\n  \"nextThoughtNeeded\": false,\n  \"confidence\": 0.5,\n  \"assumptions\": [],\n  \"critique\": \"c\",\n  \"counterArgument\": \"ca\"\n}\n"
+	var out, errb bytes.Buffer
+	if code := runOnce(nil, strings.NewReader(pretty), &out, &errb); code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, errb.String())
+	}
+	if !strings.Contains(out.String(), `"thoughtHistoryLength":1`) {
+		t.Errorf("expected one ThoughtResponse on stdout:\n%s", out.String())
+	}
+}
+
+func TestRunOnceMalformedArg(t *testing.T) {
+	arg := "{not json"
+	var out, errb bytes.Buffer
+	if code := runOnce(&arg, strings.NewReader(""), &out, &errb); code != 1 {
+		t.Errorf("exit = %d; want 1", code)
+	}
+	if !strings.Contains(errb.String(), "argument") {
+		t.Errorf("stderr should name the source 'argument': %q", errb.String())
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout must stay clean: %q", out.String())
+	}
+}
+
+// Mirrors TestRunCLIValidationErrorRouting for the single-shot path: an
+// IsError result emits its error JSON to stdout, never stderr.
+func TestRunOnceValidationErrorRouting(t *testing.T) {
+	bad := `{"thought":"x","thoughtNumber":1,"totalThoughts":1,"nextThoughtNeeded":false,"confidence":0.5,"assumptions":[],"counterArgument":"ca"}`
+
+	var out, errb bytes.Buffer
+	if code := runOnce(&bad, strings.NewReader(""), &out, &errb); code != 1 {
+		t.Errorf("exit = %d; want 1", code)
+	}
+	if !strings.Contains(out.String(), `"status":"failed"`) || errb.Len() != 0 {
+		t.Errorf("error JSON should go to stdout only; out=%q err=%q", out.String(), errb.String())
+	}
+}
+
+// Empty stdin is a FAILURE in --once mode (there is no next line to continue
+// to) — deliberately unlike the stream loop's blank-line skip.
+func TestRunOnceEmptyStdin(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runOnce(nil, strings.NewReader("\n  \n"), &out, &errb); code != 1 {
+		t.Errorf("exit = %d; want 1", code)
+	}
+	if !strings.Contains(errb.String(), "stdin") {
+		t.Errorf("stderr should name the source 'stdin': %q", errb.String())
+	}
+}
+
+// Trailing data after the document (e.g. two NDJSON lines piped into --once)
+// is an error: --once means exactly one thought.
+func TestRunOnceTrailingData(t *testing.T) {
+	two := validOnceInput + "\n" + validOnceInput + "\n"
+	var out, errb bytes.Buffer
+	if code := runOnce(nil, strings.NewReader(two), &out, &errb); code != 1 {
+		t.Errorf("exit = %d; want 1", code)
+	}
+}

--- a/cmd/critical-thinking/root.go
+++ b/cmd/critical-thinking/root.go
@@ -26,6 +26,7 @@ func newRootCmd() *cobra.Command {
 		Example: "  critical-thinking serve\n" +
 			"  critical-thinking serve --http :3000\n" +
 			"  critical-thinking cli\n" +
+			"  critical-thinking cli --once '<thought-json>'\n" +
 			"  critical-thinking schema\n" +
 			"  critical-thinking version",
 		SilenceUsage:  true,

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -139,6 +139,12 @@ Run the engine directly, without an MCP client:
 printf '%s\n' '{"thought":"...","thoughtNumber":1,"totalThoughts":3,"nextThoughtNeeded":true,"confidence":0.6,"assumptions":[],"critique":"...","counterArgument":"...","nextStepRationale":"..."}' \
   | critical-thinking cli
 
+# Single-shot: one thought in, one result out, exit 0/1.
+critical-thinking cli --once '{"thought":"...","thoughtNumber":1,"totalThoughts":1,"nextThoughtNeeded":false,"confidence":0.6,"assumptions":[],"critique":"...","counterArgument":"..."}'
+
+# Single-shot from stdin (pretty-printed JSON is fine here):
+critical-thinking cli --once < thought.json
+
 # Print the tool contract (description + JSON Schemas) for a model to read:
 critical-thinking schema
 ```
@@ -148,3 +154,7 @@ branches accumulate across input lines. Malformed-JSON lines are diagnosed on
 stderr; a line the engine rejects emits its JSON error object to stdout (to keep
 the stream complete) and the process continues; the exit code is `1` if any line
 errored, else `0`.
+
+With `--once`, exactly one thought is processed against a fresh in-memory
+session and the process exits — `0` on success, `1` on any parse or
+validation failure, with the same stderr/stdout routing as stream mode.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,6 +75,13 @@ line) and read the result back.
 - `critical-thinking cli` prints structured `ThoughtResponse` as NDJSON — one
   JSON object per processed line, the machine-readable surface for programmatic
   callers.
+- `critical-thinking cli --once '<thought-json>'` processes exactly **one**
+  thought and exits — single-shot, for scripting and testing. The JSON comes
+  from the argument, or from stdin when the argument is omitted (any JSON
+  formatting works on stdin, including pretty-printed — it need not be one
+  line). Output is one `ThoughtResponse` JSON document; exit code is `0` on
+  success, `1` if the input fails to parse or validate. Empty input or
+  trailing data after the document is an error: `--once` means one thought.
 
 History, confidence, and branches accumulate across input lines that share an
 `episodeId` (absent → the `"default"` episode) within one run


### PR DESCRIPTION
## Summary
- Adds a `--once` flag to the `cli` subcommand: process exactly one `ThoughtData` document (from a positional argument or stdin) against a fresh in-memory session, then exit — for scripting and testing, as a single-shot alternative to the NDJSON stream loop.
- Extracts a shared `processOne` helper so both stream mode and `--once` route through identical unmarshal → `ProcessThought` → `IsError` routing logic — no duplicated per-input contract.
- `--once` accepts pretty-printed multi-line JSON on stdin (the one input shape the NDJSON stream loop can't accept), and deliberately treats empty input or trailing data after the document as a failure (unlike the stream loop's blank-line skip — `--once` means exactly one thought).
- A positional argument without `--once` is rejected with a usage error distinct from the stream-mode failure sentinel, so the existing stream contract is unchanged.

Closes #74.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race` — 113 passed
- [x] Four task-level reviews + one independent final whole-branch review, all clean (one non-blocking phrasing nit in `docs/usage.md`, inherited from the plan text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01392A4511uPGPMdBt8z7w4q