### PR TITLE
feat: add OIDC bearer-token authentication to the HTTP transport

### DIFF
--- a/cmd/critical-thinking/auth.go
+++ b/cmd/critical-thinking/auth.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
 )
 
 // bearerToken extracts the token from an Authorization header value. The scheme match is
@@ -25,4 +31,38 @@ func bearerToken(header string) (string, bool) {
 func writeUnauthorized(w http.ResponseWriter, publicMessage string) {
 	w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
 	http.Error(w, publicMessage, http.StatusUnauthorized)
+}
+
+// newOIDCVerifier performs OIDC discovery against issuer and returns a verifier that enforces
+// signature, issuer, audience (via the aud claim), and expiry. Discovery is a network call, run
+// under a bounded context so a slow-loris / black-hole IdP cannot hang startup indefinitely (the
+// signal context passed by runHTTP has no deadline). A returned error must abort startup. The
+// Skip* options are deliberately never set — setting any of them would silently weaken the control.
+func newOIDCVerifier(ctx context.Context, issuer, audience string) (*oidc.IDTokenVerifier, error) {
+	dctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	provider, err := oidc.NewProvider(dctx, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("oidc discovery for issuer %q: %w", issuer, err)
+	}
+	return provider.Verifier(&oidc.Config{ClientID: audience}), nil
+}
+
+// requireAuth gates next behind a valid bearer token. Applied ONLY to /mcp. Any verification
+// failure — bad signature, wrong aud/iss, expired, or JWKS unavailable for an uncached key —
+// fails closed with 401. The internal error is logged at Debug only, never sent to the client.
+func requireAuth(verifier *oidc.IDTokenVerifier, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, ok := bearerToken(r.Header.Get("Authorization"))
+		if !ok {
+			writeUnauthorized(w, "missing or malformed bearer token")
+			return
+		}
+		if _, err := verifier.Verify(r.Context(), raw); err != nil {
+			slog.Debug("bearer token rejected", "error", err)
+			writeUnauthorized(w, "invalid token")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/cmd/critical-thinking/auth.go
+++ b/cmd/critical-thinking/auth.go
@@ -19,9 +19,10 @@ func bearerToken(header string) (string, bool) {
 	return tok, true
 }
 
-// writeUnauthorized emits a 401 with an RFC 6750 challenge and a generic body. It never echoes
-// the token or the internal verification error, to avoid leaking detail to the caller.
-func writeUnauthorized(w http.ResponseWriter, detail string) {
+// writeUnauthorized emits a 401 with an RFC 6750 challenge and the given publicMessage as the
+// body. Callers MUST pass only a generic, non-sensitive message — never a raw bearer token or a
+// verifier's internal error string — this function performs no sanitization of its own.
+func writeUnauthorized(w http.ResponseWriter, publicMessage string) {
 	w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
-	http.Error(w, detail, http.StatusUnauthorized)
+	http.Error(w, publicMessage, http.StatusUnauthorized)
 }

--- a/cmd/critical-thinking/auth.go
+++ b/cmd/critical-thinking/auth.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+// bearerToken extracts the token from an Authorization header value. The scheme match is
+// case-insensitive per RFC 6750/7235. The token must be non-empty and contain no whitespace.
+func bearerToken(header string) (string, bool) {
+	const scheme = "bearer "
+	if len(header) < len(scheme) || !strings.EqualFold(header[:len(scheme)], scheme) {
+		return "", false
+	}
+	tok := strings.TrimSpace(header[len(scheme):])
+	if tok == "" || strings.ContainsAny(tok, " \t") {
+		return "", false
+	}
+	return tok, true
+}
+
+// writeUnauthorized emits a 401 with an RFC 6750 challenge and a generic body. It never echoes
+// the token or the internal verification error, to avoid leaking detail to the caller.
+func writeUnauthorized(w http.ResponseWriter, detail string) {
+	w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+	http.Error(w, detail, http.StatusUnauthorized)
+}

--- a/cmd/critical-thinking/auth_test.go
+++ b/cmd/critical-thinking/auth_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBearerToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		wantTok string
+		wantOK  bool
+	}{
+		{"valid", "Bearer abc.def.ghi", "abc.def.ghi", true},
+		{"lowercase scheme", "bearer abc.def.ghi", "abc.def.ghi", true},
+		{"mixed-case scheme", "BeArEr abc.def.ghi", "abc.def.ghi", true},
+		{"trailing space trimmed", "Bearer abc.def.ghi ", "abc.def.ghi", true},
+		{"empty header", "", "", false},
+		{"scheme only", "Bearer", "", false},
+		{"scheme and space no token", "Bearer ", "", false},
+		{"wrong scheme", "Basic abc", "", false},
+		{"embedded space", "Bearer abc def", "", false},
+		{"embedded tab", "Bearer abc\tdef", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tok, ok := bearerToken(tt.header)
+			if ok != tt.wantOK || tok != tt.wantTok {
+				t.Errorf("bearerToken(%q) = (%q, %v), want (%q, %v)", tt.header, tok, ok, tt.wantTok, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestWriteUnauthorized(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeUnauthorized(rec, "invalid token")
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); got != `Bearer error="invalid_token"` {
+		t.Errorf("WWW-Authenticate = %q, want Bearer error=\"invalid_token\"", got)
+	}
+}

--- a/cmd/critical-thinking/auth_test.go
+++ b/cmd/critical-thinking/auth_test.go
@@ -1,9 +1,18 @@
 package main
 
 import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestBearerToken(t *testing.T) {
@@ -42,5 +51,137 @@ func TestWriteUnauthorized(t *testing.T) {
 	}
 	if got := rec.Header().Get("WWW-Authenticate"); got != `Bearer error="invalid_token"` {
 		t.Errorf("WWW-Authenticate = %q, want Bearer error=\"invalid_token\"", got)
+	}
+}
+
+// fakeIdP is an httptest-backed OIDC provider: it serves a discovery doc and a JWKS derived
+// from a locally generated RSA key, and can mint signed JWTs for tests.
+type fakeIdP struct {
+	server *httptest.Server
+	key    *rsa.PrivateKey
+	kid    string
+}
+
+func newFakeIdP(t *testing.T) *fakeIdP {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idp := &fakeIdP{key: key, kid: "test-key-1"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                idp.server.URL,
+			"jwks_uri":                              idp.server.URL + "/jwks",
+			"authorization_endpoint":                idp.server.URL + "/auth",
+			"token_endpoint":                        idp.server.URL + "/token",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		n := base64.RawURLEncoding.EncodeToString(key.N.Bytes())
+		e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes())
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"keys": []map[string]any{
+				{"kty": "RSA", "use": "sig", "alg": "RS256", "kid": idp.kid, "n": n, "e": e},
+			},
+		})
+	})
+	idp.server = httptest.NewServer(mux)
+	t.Cleanup(idp.server.Close)
+	return idp
+}
+
+func (idp *fakeIdP) issuer() string { return idp.server.URL }
+
+// mint signs an RS256 JWT with the given claims using idp's key (or override, if non-nil).
+func (idp *fakeIdP) mint(t *testing.T, claims map[string]any, override *rsa.PrivateKey) string {
+	t.Helper()
+	signKey := idp.key
+	if override != nil {
+		signKey = override
+	}
+	header := map[string]any{"alg": "RS256", "typ": "JWT", "kid": idp.kid}
+	enc := func(v any) string {
+		b, _ := json.Marshal(v)
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	signingInput := enc(header) + "." + enc(claims)
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, signKey, crypto.SHA256, digest[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+func validClaims(idp *fakeIdP, aud string) map[string]any {
+	now := time.Now()
+	return map[string]any{
+		"iss": idp.issuer(),
+		"sub": "user-1",
+		"aud": aud,
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+	}
+}
+
+// stubOK is the protected handler; a 200 proves auth let the request through.
+func stubOK(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }
+
+func TestRequireAuth(t *testing.T) {
+	const audience = "critical-thinking"
+	idp := newFakeIdP(t)
+	verifier, err := newOIDCVerifier(context.Background(), idp.issuer(), audience)
+	if err != nil {
+		t.Fatalf("newOIDCVerifier: %v", err)
+	}
+	otherKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+
+	tests := []struct {
+		name     string
+		authFn   func() string // returns the Authorization header value
+		wantCode int
+	}{
+		{"valid", func() string { return "Bearer " + idp.mint(t, validClaims(idp, audience), nil) }, http.StatusOK},
+		{"no header", func() string { return "" }, http.StatusUnauthorized},
+		{"malformed scheme", func() string { return "Basic xyz" }, http.StatusUnauthorized},
+		{"wrong audience", func() string { return "Bearer " + idp.mint(t, validClaims(idp, "other-service"), nil) }, http.StatusUnauthorized},
+		{"expired", func() string {
+			c := validClaims(idp, audience)
+			c["exp"] = time.Now().Add(-time.Hour).Unix()
+			return "Bearer " + idp.mint(t, c, nil)
+		}, http.StatusUnauthorized},
+		{"wrong signing key", func() string { return "Bearer " + idp.mint(t, validClaims(idp, audience), otherKey) }, http.StatusUnauthorized},
+		{"wrong issuer", func() string {
+			c := validClaims(idp, audience)
+			c["iss"] = "https://attacker.example"
+			return "Bearer " + idp.mint(t, c, nil)
+		}, http.StatusUnauthorized},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := requireAuth(verifier, http.HandlerFunc(stubOK))
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			if v := tt.authFn(); v != "" {
+				req.Header.Set("Authorization", v)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != tt.wantCode {
+				t.Errorf("code = %d, want %d", rec.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
+func TestNewOIDCVerifierDiscoveryFailure(t *testing.T) {
+	// An unreachable issuer must return an error (fail fast at startup).
+	_, err := newOIDCVerifier(context.Background(), "http://127.0.0.1:1/nope", "aud")
+	if err == nil {
+		t.Fatal("expected discovery error for unreachable issuer, got nil")
 	}
 }

--- a/cmd/critical-thinking/config.go
+++ b/cmd/critical-thinking/config.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -34,6 +37,8 @@ func bindFlags(v *viper.Viper, flags *pflag.FlagSet) error {
 type httpConfig struct {
 	AllowedOrigins []string
 	HTTPHost       string
+	OIDCIssuer     string
+	OIDCAudience   string
 }
 
 // httpConfigFromViper extracts the HTTP settings, reusing parseAllowedOrigins as
@@ -42,5 +47,19 @@ func httpConfigFromViper(v *viper.Viper) httpConfig {
 	return httpConfig{
 		AllowedOrigins: parseAllowedOrigins(v.GetString("allowed_origins")),
 		HTTPHost:       v.GetString("http_host"),
+		OIDCIssuer:     strings.TrimSpace(v.GetString("oidc_issuer")),
+		OIDCAudience:   strings.TrimSpace(v.GetString("oidc_audience")),
 	}
+}
+
+// validateAuth fails fast on the one dangerous misconfiguration: an issuer set without an
+// audience, which would leave the aud claim unchecked. Pure (no network) so it runs before
+// any port is bound and is unit-testable. Empty issuer = auth disabled = valid.
+func (c httpConfig) validateAuth() error {
+	if c.OIDCIssuer != "" && c.OIDCAudience == "" {
+		return errors.New("CTHINK_OIDC_ISSUER is set but CTHINK_OIDC_AUDIENCE is empty; " +
+			"refusing to start with authentication misconfigured (an empty audience would " +
+			"disable audience validation)")
+	}
+	return nil
 }

--- a/cmd/critical-thinking/config_test.go
+++ b/cmd/critical-thinking/config_test.go
@@ -96,3 +96,50 @@ func TestBindFlagsDefaultWhenNeither(t *testing.T) {
 		t.Error("verbose = true, want false (default)")
 	}
 }
+
+func TestHTTPConfigFromViperOIDC(t *testing.T) {
+	t.Setenv("CTHINK_OIDC_ISSUER", "https://issuer.example")
+	t.Setenv("CTHINK_OIDC_AUDIENCE", "critical-thinking")
+	v := newConfigViper()
+	cfg := httpConfigFromViper(v)
+	if cfg.OIDCIssuer != "https://issuer.example" {
+		t.Errorf("OIDCIssuer = %q, want https://issuer.example", cfg.OIDCIssuer)
+	}
+	if cfg.OIDCAudience != "critical-thinking" {
+		t.Errorf("OIDCAudience = %q, want critical-thinking", cfg.OIDCAudience)
+	}
+}
+
+func TestHTTPConfigFromViperOIDCTrimsWhitespace(t *testing.T) {
+	t.Setenv("CTHINK_OIDC_ISSUER", "  https://issuer.example  ")
+	t.Setenv("CTHINK_OIDC_AUDIENCE", "   ") // whitespace-only → must collapse to empty
+	v := newConfigViper()
+	cfg := httpConfigFromViper(v)
+	if cfg.OIDCIssuer != "https://issuer.example" {
+		t.Errorf("OIDCIssuer = %q, want trimmed https://issuer.example", cfg.OIDCIssuer)
+	}
+	if cfg.OIDCAudience != "" {
+		t.Errorf("OIDCAudience = %q, want empty after trim", cfg.OIDCAudience)
+	}
+}
+
+func TestValidateAuth(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     httpConfig
+		wantErr bool
+	}{
+		{"both empty (disabled)", httpConfig{}, false},
+		{"both set", httpConfig{OIDCIssuer: "https://i.example", OIDCAudience: "aud"}, false},
+		{"issuer set, audience empty", httpConfig{OIDCIssuer: "https://i.example"}, true},
+		{"audience set, issuer empty (disabled)", httpConfig{OIDCAudience: "aud"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.validateAuth()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateAuth() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/critical-thinking/mcpserver.go
+++ b/cmd/critical-thinking/mcpserver.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/jacaudi/critical-thinking/internal/thinking"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -57,42 +58,37 @@ func runStdio() error {
 // the SDK closes a session we have no callback, so the count drifts upward.
 // /health exposes it as `sessionsCreated` to make the semantics explicit.
 func runHTTP(cfg httpConfig, addr string) error {
-	// Wire the configured allowed origins (CTHINK_ALLOWED_ORIGINS) into the SDK's
-	// CSRF protection so browser clients from those origins aren't rejected by the
-	// SDK's default same-origin policy. Non-browser callers (no Origin /
-	// no Sec-Fetch-Site) are still allowed regardless.
-	csrf := http.NewCrossOriginProtection()
-	for _, o := range cfg.AllowedOrigins {
-		if err := csrf.AddTrustedOrigin(o); err != nil {
-			return fmt.Errorf("invalid CTHINK_ALLOWED_ORIGINS entry %q: %w", o, err)
-		}
+	if err := cfg.validateAuth(); err != nil {
+		return err // fail fast: never bind a port with auth misconfigured
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	registry := newSessionRegistry()
+	var verifier *oidc.IDTokenVerifier
+	if cfg.OIDCIssuer != "" {
+		v, err := newOIDCVerifier(ctx, cfg.OIDCIssuer, cfg.OIDCAudience)
+		if err != nil {
+			return err
+		}
+		verifier = v
+		slog.Info("OIDC authentication ENABLED", "issuer", cfg.OIDCIssuer, "audience", cfg.OIDCAudience)
+	} else {
+		slog.Warn("OIDC authentication DISABLED (CTHINK_OIDC_ISSUER not set); /mcp is unauthenticated")
+	}
 
-	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
-		state := thinking.NewServer()
-		registry.add()
-		slog.Debug("http session created", "sessionsCreated", registry.count())
-		return newMCPServer(state)
-	}, &mcp.StreamableHTTPOptions{
-		SessionTimeout:        idleTimeout,
-		CrossOriginProtection: csrf,
-	})
+	registry := newSessionRegistry()
+	rootHandler, err := buildHTTPHandler(cfg, verifier, registry)
+	if err != nil {
+		return err
+	}
 
 	// addr like ":3000" already includes the colon; combine with the configured host.
 	listenAddr := cfg.HTTPHost + addr
 
-	mux := http.NewServeMux()
-	mux.Handle("/mcp", handler)
-	mux.HandleFunc("/health", makeHealthHandler(registry))
-
 	srv := &http.Server{
 		Addr:              listenAddr,
-		Handler:           withCORS(mux, cfg.AllowedOrigins),
+		Handler:           rootHandler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
@@ -110,6 +106,42 @@ func runHTTP(cfg httpConfig, addr string) error {
 		return fmt.Errorf("listen: %w", err)
 	}
 	return nil
+}
+
+// buildHTTPHandler assembles the full HTTP handler chain and is the single source of truth for the
+// /mcp+/health wiring, called by runHTTP in production and by the integration tests directly.
+// /mcp is wrapped by requireAuth iff verifier != nil; /health is always bare; withCORS is outermost.
+func buildHTTPHandler(cfg httpConfig, verifier *oidc.IDTokenVerifier, registry *sessionRegistry) (http.Handler, error) {
+	// Wire the configured allowed origins (CTHINK_ALLOWED_ORIGINS) into the SDK's
+	// CSRF protection so browser clients from those origins aren't rejected by the
+	// SDK's default same-origin policy. Non-browser callers (no Origin /
+	// no Sec-Fetch-Site) are still allowed regardless.
+	csrf := http.NewCrossOriginProtection()
+	for _, o := range cfg.AllowedOrigins {
+		if err := csrf.AddTrustedOrigin(o); err != nil {
+			return nil, fmt.Errorf("invalid CTHINK_ALLOWED_ORIGINS entry %q: %w", o, err)
+		}
+	}
+
+	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
+		state := thinking.NewServer()
+		registry.add()
+		slog.Debug("http session created", "sessionsCreated", registry.count())
+		return newMCPServer(state)
+	}, &mcp.StreamableHTTPOptions{
+		SessionTimeout:        idleTimeout,
+		CrossOriginProtection: csrf,
+	})
+
+	var mcpEndpoint http.Handler = handler
+	if verifier != nil {
+		mcpEndpoint = requireAuth(verifier, handler)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", mcpEndpoint)
+	mux.HandleFunc("/health", makeHealthHandler(registry))
+	return withCORS(mux, cfg.AllowedOrigins), nil
 }
 
 // newMCPServer constructs a configured *mcp.Server with the criticalthinking

--- a/cmd/critical-thinking/mcpserver_test.go
+++ b/cmd/critical-thinking/mcpserver_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -343,5 +344,81 @@ func TestThinkingCurrentResourceIsPerSession(t *testing.T) {
 	}
 	if strings.Contains(readB, "A-resource") {
 		t.Errorf("session B snapshot LEAKED session A's tag; got:\n%s", readB)
+	}
+}
+
+func TestHTTPAuthEnabledGatesMCP(t *testing.T) {
+	idp := newFakeIdP(t)
+	verifier, err := newOIDCVerifier(context.Background(), idp.issuer(), "critical-thinking")
+	if err != nil {
+		t.Fatalf("newOIDCVerifier: %v", err)
+	}
+	h, err := buildHTTPHandler(httpConfig{}, verifier, newSessionRegistry())
+	if err != nil {
+		t.Fatalf("buildHTTPHandler: %v", err)
+	}
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	// /mcp without a token → 401
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/mcp", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("/mcp unauthenticated status = %d, want 401", resp.StatusCode)
+	}
+
+	// /health without a token → 200 (probes must never be gated)
+	hresp, err := http.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = hresp.Body.Close()
+	if hresp.StatusCode != http.StatusOK {
+		t.Errorf("/health status = %d, want 200 (must stay unauthenticated)", hresp.StatusCode)
+	}
+}
+
+func TestHTTPAuthDisabledLeavesMCPOpen(t *testing.T) {
+	// verifier nil = auth disabled: an MCP initialize handshake must succeed without a token,
+	// proving backward compatibility. newHTTPClient fatals if the handshake fails.
+	h, err := buildHTTPHandler(httpConfig{}, nil, newSessionRegistry())
+	if err != nil {
+		t.Fatalf("buildHTTPHandler: %v", err)
+	}
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+	c := newHTTPClient(t, ts.URL) // performs initialize without any Authorization header
+	if c.sessionID == "" {
+		t.Fatal("expected a session id from an unauthenticated handshake when auth is disabled")
+	}
+}
+
+func TestHTTPAuthOptionsBypass(t *testing.T) {
+	// OPTIONS preflight must short-circuit in withCORS before auth, returning 200 without a token.
+	idp := newFakeIdP(t)
+	verifier, err := newOIDCVerifier(context.Background(), idp.issuer(), "critical-thinking")
+	if err != nil {
+		t.Fatalf("newOIDCVerifier: %v", err)
+	}
+	h, err := buildHTTPHandler(httpConfig{}, verifier, newSessionRegistry())
+	if err != nil {
+		t.Fatalf("buildHTTPHandler: %v", err)
+	}
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodOptions, ts.URL+"/mcp", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("OPTIONS /mcp status = %d, want 200 (preflight must bypass auth)", resp.StatusCode)
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,8 @@
 |---|---|---|
 | `CTHINK_ALLOWED_ORIGINS` | (empty) | Comma-separated list of browser origins permitted to call `/mcp`. Wired into both the outer CORS layer and the SDK's CSRF protection (`http.CrossOriginProtection.AddTrustedOrigin`). Default rejects all browser origins. Non-browser callers (no `Origin` / no `Sec-Fetch-Site` header) are unaffected. |
 | `CTHINK_HTTP_HOST` | `127.0.0.1` | Host the HTTP server binds to. Set to `0.0.0.0` to bind all interfaces (the published Docker image sets this). |
+| `CTHINK_OIDC_ISSUER` | (empty) | OIDC issuer URL for bearer-token auth on `/mcp`. **Empty disables auth** (default; preserves prior behavior). When set, every `/mcp` request must carry a valid `Authorization: Bearer <jwt>`. The server performs OIDC discovery at startup and **fails to start** if the issuer is unreachable. |
+| `CTHINK_OIDC_AUDIENCE` | (empty) | Expected `aud` claim. **Required when `CTHINK_OIDC_ISSUER` is set** — the server refuses to start otherwise (an empty audience would disable audience validation). |
 | `CTHINK_VERBOSE` | `false` | Enables debug logging (and the stdio JSON-RPC frame trace). Env equivalent of `--verbose`; the flag overrides it. |
 | `CTHINK_LOG_FORMAT` | `text` | Log handler format: `text` or `json`. Env equivalent of `--log-format`; the flag overrides it. |
 
@@ -66,3 +68,41 @@ There is no callback fired when the SDK closes a session, so the in-process regi
 When `CTHINK_ALLOWED_ORIGINS` is empty, browser requests with an `Origin` header are rejected with HTTP 403. Non-browser clients (no `Origin`, no `Sec-Fetch-Site`) bypass the check entirely. When set, matching origins receive `Access-Control-Allow-Origin: <origin>`, `Access-Control-Allow-Credentials: true`, `Access-Control-Expose-Headers: mcp-session-id`, and a `Vary: Origin` header for cache-poisoning mitigation.
 
 The same origin list is registered with the SDK's CSRF protection (`http.CrossOriginProtection.AddTrustedOrigin`) so the SDK's same-origin policy doesn't double-reject permitted browser callers.
+
+## Authentication (OIDC bearer tokens)
+
+The HTTP transport optionally authenticates `/mcp` with OIDC bearer tokens. It is **disabled by
+default**: with `CTHINK_OIDC_ISSUER` unset, behavior is unchanged and `/mcp` is unauthenticated
+(the server logs a startup warning saying so).
+
+When `CTHINK_OIDC_ISSUER` is set (and `CTHINK_OIDC_AUDIENCE` provided):
+
+- Every `/mcp` request must carry `Authorization: Bearer <jwt>`. The token's **signature, issuer,
+  audience (`aud`), and expiry** are validated against the issuer's published JWKS. Any failure
+  returns `401` with a `WWW-Authenticate: Bearer` challenge; the internal reason is never sent to
+  the client.
+- `/health` stays **unauthenticated** so liveness/readiness probes keep working.
+- `OPTIONS` preflight is unaffected — CORS short-circuits it before auth runs.
+
+> **Token requirements (read before configuring your IdP):**
+> - The presented bearer token **must be a signed JWT** whose `aud` claim **equals**
+>   `CTHINK_OIDC_AUDIENCE`. Request tokens for this audience from your IdP accordingly (many IdPs set
+>   `aud` from a "resource"/"audience"/"scope" parameter on the token request). A token whose `aud`
+>   is a different resource URI or client ID will be rejected with `401`.
+> - **Opaque (non-JWT) access tokens are not supported.** Some IdPs issue opaque bearer tokens that
+>   can only be validated via a token-introspection endpoint (RFC 7662). This design validates JWTs
+>   against the issuer's JWKS only — it does not call introspection — so opaque tokens will not
+>   verify. Configure your IdP to issue JWT access/ID tokens for this audience.
+
+**Security posture:**
+
+- **Fail fast at startup.** If `CTHINK_OIDC_ISSUER` is set but `CTHINK_OIDC_AUDIENCE` is empty, or the
+  issuer's discovery endpoint is unreachable at boot, the server **exits non-zero** rather than
+  serving. A server that cannot authenticate should not start. (In Kubernetes, rely on the restart
+  policy / readiness ordering if the IdP and this server start together.)
+- **Fail closed at runtime.** JWKS keys are cached and rotated automatically, so a brief IdP outage
+  does not break verification of already-seen signing keys. A token that cannot be cryptographically
+  verified is always rejected — the server never falls back to accepting unverified tokens.
+
+Authentication is orthogonal to CORS and the SDK's `CrossOriginProtection`: all three apply
+independently.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/coreos/go-oidc/v3 v3.20.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -24,7 +25,7 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/oauth2 v0.35.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jacaudi/critical-thinking
 go 1.26.4
 
 require (
+	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/modelcontextprotocol/go-sdk v1.6.0
 	github.com/spf13/cobra v1.10.2
@@ -11,8 +12,8 @@ require (
 )
 
 require (
-	github.com/coreos/go-oidc/v3 v3.20.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
@@ -57,8 +59,6 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
-golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/coreos/go-oidc/v3 v3.20.0 h1:EtE0WIBHk03N+DqGkY4+UONzzZHk7amKt6IyNd7OsZE=
+github.com/coreos/go-oidc/v3 v3.20.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -57,6 +59,8 @@ go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=


### PR DESCRIPTION
## Summary
- Adds optional OIDC bearer-token authentication to the Streamable HTTP transport, gating only `/mcp` — disabled by default (empty `CTHINK_OIDC_ISSUER`, preserving current behavior exactly).
- **Fail-fast at startup:** `CTHINK_OIDC_ISSUER` set without `CTHINK_OIDC_AUDIENCE` refuses to start (an empty audience would disable audience validation); an unreachable issuer at OIDC discovery time (bounded 10s) also aborts startup. Never binds a port with auth misconfigured.
- **Fail-closed at runtime:** any verification failure (bad signature, wrong `aud`/`iss`, expired, JWKS unavailable) returns `401` with a generic body — the internal error is logged at `slog.Debug` only, never sent to the client. No `Skip*` verifier options are ever set.
- Extracts `buildHTTPHandler(cfg, verifier, registry) (http.Handler, error)` out of `runHTTP` — a testability seam called by both production code and the integration tests, so the tests exercise real wiring. This function is also the hard prerequisite for #76 (otel-instrumentation), which will wrap it.
- `/health` stays unauthenticated (probes keep working); `OPTIONS` preflight bypasses auth via the existing CORS short-circuit; `withCORS` stays outermost.

Closes #75.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — no issues
- [x] `go test ./... -race` — 134 passed (fake in-process OIDC provider with hand-minted RS256 JWTs, zero new test dependencies)
- [x] Manual smoke: auth disabled → `/health` 200, startup log confirms "OIDC authentication DISABLED"
- [x] Manual smoke: `CTHINK_OIDC_ISSUER` set without audience → exits non-zero, no port bound
- [x] Six task-level reviews (one with a fix-and-reverify cycle) plus an independent, security-focused final whole-branch review — all clean. Full silent-disable audit re-traced end-to-end in the final review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01392A4511uPGPMdBt8z7w4q