### PR TITLE
fix(ci): pin conventional-changelog-conventionalcommits to v9 in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       use-github-app: true
       go: true
       goreleaser: true
-      extra-plugins: '@semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog-conventionalcommits'
+      extra-plugins: '@semantic-release/changelog @semantic-release/git @semantic-release/exec conventional-changelog-conventionalcommits@9'
     secrets:
       app-id: ${{ secrets.BOT_APP_ID }}
       app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

The release changelog/GitHub Release notes have been empty (version header only, no commit list) for every release since v1.11.0 — five releases today, all with genuinely missing content.

**Root cause:** `.github/workflows/release.yml` installs semantic-release's extra plugins completely unpinned (`npm install --no-save`, no lockfile). `conventional-changelog-conventionalcommits` had a major bump to v10.0.0 on 2026-06-26 (iterating to v10.2.1 by 2026-07-04) — after the last successful release (v1.10.1, 2026-06-22) and before today's releases. Since then, every CI run resolves to whatever's tagged `latest` (now v10.x), and `release-notes-generator`'s use of that package silently produces an empty notes body instead of erroring — `generateNotes` reports "Completed step" with no failure, so CI stays green while the actual changelog content is lost.

Confirmed via:
- `gh run view --log` on the release workflow: `commit-analyzer` correctly finds and classifies commits (e.g. "Found 1 commits since last release... release type is minor"), so the bug is isolated to `release-notes-generator`, not commit analysis.
- Isolated the single-clean-commit case (v1.12.0, one `refactor(...)` commit, no mixed types) — still empty, ruling out a commit-message-format theory.
- `registry.npmjs.org` confirms `conventional-changelog-conventionalcommits@10.0.0` published 2026-06-26T19:37:51Z, `latest` now at 10.2.1.

## Fix

Pin `conventional-changelog-conventionalcommits` to `@9` (major-version pin, matching the existing `semantic-release@24` pin style already used in this file) — the last known-good major line as of the last successful changelog generation.

## Not included in this PR

The five affected releases (v1.11.0–v1.15.0) already have empty CHANGELOG.md entries and GitHub Release bodies on `main`. Backfilling those retroactively is a separate, judgment-call action (rewriting already-published release notes) — flagging it for a follow-up decision rather than doing it here.

## Test plan
- [x] Single-line, config-only diff — no application code touched.
- [ ] Next release after merge will confirm the fix (can't dry-run the shared reusable workflow locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01392A4511uPGPMdBt8z7w4q